### PR TITLE
Patch 1

### DIFF
--- a/printing/android/build.gradle
+++ b/printing/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
     }
 }
 
@@ -26,7 +26,7 @@ android {
 
     defaultConfig {
         minSdkVersion 19
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    api 'com.android.support:appcompat-v7:26.1.0'
+    api 'androidx.appcompat:appcompat:1.0.2'
 }

--- a/printing/android/gradle.properties
+++ b/printing/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableJetifier=true
+android.useAndroidX=true


### PR DESCRIPTION
migration to androidx
latest stable flutter 1.2.1 has a breaking change and forces applications to migrate from android.support to androidx packages. this pull request should do the trick
more info here:

1. https://flutter.dev/docs/development/packages-and-plugins/androidx-compatibility
2. https://medium.com/@gabrc52/how-to-migrate-your-flutter-app-to-androidx-1202ad43c8c8