### PR TITLE
Update call to FlutterErrorDetails to use a DignosticsNode instead of String

### DIFF
--- a/printing/lib/src/asset_utils.dart
+++ b/printing/lib/src/asset_utils.dart
@@ -57,7 +57,7 @@ Future<PdfImage> pdfImageFromImageProvider(
       onError(exception, stackTrace);
     } else {
       FlutterError.reportError(FlutterErrorDetails(
-        context: 'image failed to load',
+        context: DiagnosticsNode.message('image failed to load'),
         library: 'printing',
         exception: exception,
         stack: stackTrace,


### PR DESCRIPTION
Fixes #67.

Note that this is a breaking change as anyone running a previous version of flutter won't be able to compile if they have this change until they upgrade, so it might be worth bumping the version....