### PR TITLE
Fix an issue when using unicode font like Chinese.

### DIFF
--- a/pdf/lib/src/ttf_parser.dart
+++ b/pdf/lib/src/ttf_parser.dart
@@ -89,9 +89,9 @@ class TtfParser {
 
   int get descent => bytes.getInt16(tableOffsets[hhea_table] + 6);
 
-  int get numOfLongHorMetrics => bytes.getInt16(tableOffsets[hhea_table] + 34);
+  int get numOfLongHorMetrics => bytes.getUint16(tableOffsets[hhea_table] + 34);
 
-  int get numGlyphs => bytes.getInt16(tableOffsets[maxp_table] + 4);
+  int get numGlyphs => bytes.getUint16(tableOffsets[maxp_table] + 4);
 
   String get fontName => _fontName;
 


### PR DESCRIPTION
According to apple's document about 'heea' and 'maxp', these two fields should be unsigned int16.

https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6maxp.html
https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6hhea.html