### PR TITLE
Exception handling fix in Printing.layoutPdf (#238)

### DIFF
--- a/printing/lib/src/printing.dart
+++ b/printing/lib/src/printing.dart
@@ -122,14 +122,11 @@ mixin Printing {
     };
 
     await _channel.invokeMethod<int>('printPdf', params);
-    bool result = false;
     try {
-      result = await job.onCompleted.future;
-    } catch (e) {
-      print('Document not printed: $e');
+      return await job.onCompleted.future;
+    } finally {
+      _printJobs.remove(job.index);
     }
-    _printJobs.remove(job.index);
-    return result;
   }
 
   static Future<Map<dynamic, dynamic>> printingInfo() async {


### PR DESCRIPTION
Fixes issue #238 by causing ```Printing.layoutPdf``` to throw exceptions instead of handling them itself.