### PR TITLE
Add color to dropdown item in pageFormat selector in page preview

### DIFF
--- a/printing/CHANGELOG.md
+++ b/printing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.6.2
+
+- Added theme color to dropdown item in pageFormat selector in page preview
+
 ## 3.6.1
 
 - Update the example to use PdfPreview

--- a/printing/lib/src/pdf_preview.dart
+++ b/printing/lib/src/pdf_preview.dart
@@ -302,7 +302,11 @@ class _PdfPreviewState extends State<PdfPreview> {
               final key = keys[index];
               final val = _pageFormats[key];
               return DropdownMenuItem<PdfPageFormat>(
-                child: Text(key),
+                child: Text(key,
+                  style: TextStyle(
+                    color: theme.accentIconTheme.color
+                  )
+                ),
                 value: val,
               );
             },

--- a/printing/lib/src/pdf_preview.dart
+++ b/printing/lib/src/pdf_preview.dart
@@ -291,6 +291,7 @@ class _PdfPreviewState extends State<PdfPreview> {
       final keys = _pageFormats.keys.toList();
       actions.add(
         DropdownButton<PdfPageFormat>(
+          dropdownColor: theme.primaryColor,
           icon: Icon(
             Icons.arrow_drop_down,
             color: theme.accentIconTheme.color,

--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -4,7 +4,7 @@ description: Plugin that allows Flutter apps to generate and print documents to 
 homepage: https://github.com/DavBfr/dart_pdf/tree/master/printing
 repository: https://github.com/DavBfr/dart_pdf
 issue_tracker: https://github.com/DavBfr/dart_pdf/issues
-version: 3.6.1
+version: 3.6.2
 
 environment:
   sdk: ">=2.3.0 <3.0.0"


### PR DESCRIPTION
In my project, I have a dark bar theme so, the title of the text in dropDown, which is de default text color, so black in my case, cant't see well.

I change the color to the theme.accentIconTheme.color, but, when you tap, the background was white so I need to change the background color too.

I think maybe this problem was for other developers, so, this is the solution.

![color_in_bar_print](https://user-images.githubusercontent.com/5502981/94026816-6fd20280-fdba-11ea-9f07-d642e14231fd.png)



