### PR TITLE
Remove unnecessary _raster call

### DIFF
--- a/printing/lib/src/pdf_preview.dart
+++ b/printing/lib/src/pdf_preview.dart
@@ -263,7 +263,6 @@ class _PdfPreviewState extends State<PdfPreview> {
         setState(() {
           infoLoaded = true;
           info = _info;
-          _raster();
         });
       });
     }


### PR DESCRIPTION
I was using the `PdfPreview` widget included in the printing package and I noticed that the build function is always called twice:
```dart
PdfPreview(
  maxPageWidth: 700,
  build: (format) {
    print("Callback");
    return generatePdf();
  },
),
```

The problem seems to be in `didChangeDependencies`, where the `_raster()` function is indeed called twice. As far as I saw, the first call isn't providing any necessary info for the remaining code, and the second call will be executed anyways.

I ran the tests in both pdf and printing packages, and they all passed correctly.