### PR TITLE
Allow host app to override pdfium version

### DIFF
--- a/printing/linux/CMakeLists.txt
+++ b/printing/linux/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.10)
 set(PROJECT_NAME "printing")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
-set(PDFIUM_VERSION "4627")
+set(PDFIUM_VERSION "4627" CACHE STRING "Version of pdfium used")
 
 if(${PDFIUM_VERSION} STREQUAL "latest")
   set(
@@ -26,7 +26,7 @@ if(${PDFIUM_VERSION} STREQUAL "latest")
 else()
   set(
     PDFIUM_URL
-    "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F${PDFIUM_VERSION}/pdfium-linux.tgz"
+    "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/${PDFIUM_VERSION}/pdfium-linux.tgz"
     )
 endif()
 

--- a/printing/windows/CMakeLists.txt
+++ b/printing/windows/CMakeLists.txt
@@ -17,7 +17,7 @@ set(PROJECT_NAME "printing")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
 set(ARCH "x64")
-set(PDFIUM_VERSION "4627")
+set(PDFIUM_VERSION "4627" CACHE STRING "Version of pdfium used")
 
 if(${PDFIUM_VERSION} STREQUAL "latest")
   set(
@@ -27,7 +27,7 @@ if(${PDFIUM_VERSION} STREQUAL "latest")
 else()
   set(
     PDFIUM_URL
-    "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F${PDFIUM_VERSION}/pdfium-windows-${ARCH}.zip"
+    "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/${PDFIUM_VERSION}/pdfium-windows-${ARCH}.zip"
     )
 endif()
 


### PR DESCRIPTION
Allows the host app to override the version of pdfium by adding the following to the host apps CMakeLists.txt file:
```
 set(PDFIUM_VERSION "4638" CACHE STRING "")
```