### PR TITLE
Remove extra scroll bars on desktop

### DIFF
--- a/printing/lib/src/preview/pdf_preview.dart
+++ b/printing/lib/src/preview/pdf_preview.dart
@@ -491,10 +491,7 @@ class _PdfPreviewState extends State<PdfPreview> with PdfPreviewRaster {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
-        Expanded(
-            child: scrollController.hasClients
-                ? Scrollbar(controller: scrollController, child: scrollView)
-                : scrollView),
+        Expanded(child: scrollView),
         if (actions.isNotEmpty && widget.useActions)
           IconTheme.merge(
             data: IconThemeData(


### PR DESCRIPTION
As of flutter 2.2, scrollbars are added by default on the desktop platform. In the current version of this, in certain scenarios, two scroll bars are being shown in the PdfPreview widget.

This removes the extra scrollbar.