### PR TITLE
Support latest version of package:path_parsing

### DIFF
--- a/pdf/pubspec.yaml
+++ b/pdf/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   crypto: ^3.0.0
   image: ^3.0.1
   meta: ^1.3.0
-  path_parsing: ^0.2.0
+  path_parsing: ">=0.2.0 <=2.0.0"
   vector_math: ^2.1.0
   xml: ^5.1.0
 


### PR DESCRIPTION
`path_parsing` has a `v1.0.0`. That would be great to widen the constraint to allow it.