### PR TITLE
Improve outlines containing non-sequential level increments

### DIFF
--- a/pdf/lib/src/widgets/annotations.dart
+++ b/pdf/lib/src/widgets/annotations.dart
@@ -623,24 +623,28 @@ class Outline extends Anchor {
       color: color,
       style: style,
       page: context.pageNumber,
-    );
+    )..effectiveLevel = level;
 
-    var parent = context.document.outline;
-    var l = level;
+    final root = context.document.outline;
 
-    while (l > 0) {
-      if (parent.effectiveLevel == l) {
-        break;
-      }
-
-      if (parent.outlines.isEmpty) {
-        parent.effectiveLevel = level;
-        break;
-      }
-      parent = parent.outlines.last;
-      l--;
+    // find the most recently added outline
+    var actualLevel= -1;
+    var candidate = root;
+    while (candidate.outlines.isNotEmpty) {
+      candidate = candidate.outlines.last;
+      actualLevel++;
     }
 
-    parent.add(_outline!);
+    // find the latest added outline with a level lower than ours
+    while (candidate != root) {
+      final candidateLevel = candidate.effectiveLevel ?? actualLevel;
+      if (candidateLevel < level) {
+        break;
+      }
+      candidate = candidate.parent!;
+      actualLevel--;
+    }
+
+    candidate.add(_outline!);
   }
 }


### PR DESCRIPTION
Fixes #892.

For well-formed documents, the output should be unaffected.

I define well-formed as:
- The first added Outline level is 0
- Any consecutive Outline has a level between 0 and the level of the previous Outline + 1

This change handles the case where one of those rules is broken.

I've used the following principles, which are always true for well-formed Outlines:
1. Any two consecutive Outlines with the same level will always be siblings (have the same parent)
2. Any Outline that is immediately followed by an Outline with a higher level becomes its parent
3. Any two Outlines with the same level that have only Outlines between them with the same or a higher level will always be siblings
4. Any two Outlines with the same level that have at least one Outline between them with a lower level will never be siblings

In this pull request, I've re-purposed the `PdfOutline.effectiveLevel` field to contain the Outline level given at construction. I don't know if the comment `/// External level for this outline` would cover the current usage. Searching in the `pdf` code did not reveal any other usages than the ones in Outline. Also, the code can gracefully handle the absence of any value, so editing an existing pdf would not generate an error, however the principles can no longer be enforced when interoperating with a previously generated document since the original levels are no longer available.

I've added some tests but since the outline generation needs a new document per test I've not added additional pdf files. I verify the results only in memory, and let the test fail of the results are not as expected.

