### PR TITLE
Update PrintJob.swift

### DIFF
--- a/printing/ios/Classes/PrintJob.swift
+++ b/printing/ios/Classes/PrintJob.swift
@@ -75,7 +75,7 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
 
         let printInfo = UIPrintInfo.printInfo()
         printInfo.jobName = jobName!
-        printInfo.outputType = .general
+        DispatchQueue.main.async { printInfo.outputType = .general }
         if orientation != nil {
             printInfo.orientation = orientation!
             orientation = nil


### PR DESCRIPTION
Adding DispatchQueue to resolve issue with iOS crashing after canceling print job and relaunching. #886 