### PR TITLE
Replace function memfd_create by syscall(SYS_memfd_create)

### DIFF
--- a/printing/CHANGELOG.md
+++ b/printing/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Use RENDER_MODE_FOR_DISPLAY on Android
 - Enable usage of printer's settings on Windows [Alban Lecuivre]
 - Update android projects (mavenCentral, compileSdkVersion 30, gradle:4.1.0)
+- Use syscall(SYS_memfd_create) instead of glibc function memfd_create
 
 ## 5.6.6
 

--- a/printing/linux/print_job.cc
+++ b/printing/linux/print_job.cc
@@ -17,9 +17,11 @@
 #include "print_job.h"
 
 #include <stdlib.h>
-#include <sys/mman.h>
+#include <unistd.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <linux/memfd.h>
 #include <cstring>
 #include <string>
 
@@ -200,7 +202,7 @@ bool print_job::print_pdf(const gchar* name,
 }
 
 void print_job::write_job(const uint8_t data[], size_t size) {
-  auto fd = memfd_create("printing", 0);
+  auto fd = syscall(SYS_memfd_create, "printing", 0);
   size_t offset = 0;
   ssize_t n;
   while ((n = write(fd, data + offset, size - offset)) >= 0 &&


### PR DESCRIPTION
Replace function memfd_create by syscall(SYS_memfd_create) to reduce required glibc version