### PR TITLE
Fix Bidirectional text (Arabic + Latin words) order and line breakers issue 

### DIFF
--- a/pdf/lib/src/pdf/font/arabic.dart
+++ b/pdf/lib/src/pdf/font/arabic.dart
@@ -24,12 +24,7 @@ const Map<int, dynamic> _arabicSubstitionA = <int, dynamic>{
   0x0623: <int>[1571, 0xFE84], // ARABIC LETTER ALEF WITH HAMZA ABOVE
   0x0624: <int>[1572, 0xFE86], // ARABIC LETTER WAW WITH HAMZA ABOVE
   0x0625: <int>[1573, 0xFE88], // ARABIC LETTER ALEF WITH HAMZA BELOW
-  0x0626: <int>[
-    1574,
-    0xFE8A,
-    0xFE8B,
-    0xFE8C
-  ], // ARABIC LETTER YEH WITH HAMZA ABOVE
+  0x0626: <int>[1574, 0xFE8A, 0xFE8B, 0xFE8C], // ARABIC LETTER YEH WITH HAMZA ABOVE
   0x0627: <int>[1575, 0xFE8E], // ARABIC LETTER ALEF
   0x0628: <int>[1576, 0xFE90, 0xFE91, 0xFE92], // ARABIC LETTER BEH
   0x0629: <int>[1577, 0xFE94], // ARABIC LETTER TEH MARBUTA
@@ -87,12 +82,7 @@ const Map<int, dynamic> _arabicSubstitionA = <int, dynamic>{
   0x06B3: <int>[0xFB96, 0xFB97, 0xFB98, 0xFB99], // ARABIC LETTER GUEH
   0x06BA: <int>[0xFB9E, 0xFB9F], // ARABIC LETTER NOON GHUNNA
   0x06BB: <int>[0xFBA0, 0xFBA1, 0xFBA2, 0xFBA3], // ARABIC LETTER RNOON
-  0x06BE: <int>[
-    0xFBAA,
-    0xFBAB,
-    0xFBAC,
-    0xFBAD
-  ], // ARABIC LETTER HEH DOACHASHMEE
+  0x06BE: <int>[0xFBAA, 0xFBAB, 0xFBAC, 0xFBAD], // ARABIC LETTER HEH DOACHASHMEE
   0x06C0: <int>[0xFBA4, 0xFBA5], // ARABIC LETTER HEH WITH YEH ABOVE
   0x06C1: <int>[0xFBA6, 0xFBA7, 0xFBA8, 0xFBA9], // ARABIC LETTER HEH GOAL
   0x06C5: <int>[0xFBE0, 0xFBE1], // ARABIC LETTER KIRGHIZ OE
@@ -126,12 +116,9 @@ const Map<int, dynamic> _diacriticLigatures = <int, dynamic>{
 
 const Map<int, dynamic> _ligatures = <int, dynamic>{
   0xFEDF: <int, int>{
-    0xFE82:
-        0xFEF5, // ARABIC LIGATURE LAM WITH ALEF WITH MADDA ABOVE ISOLATED FORM
-    0xFE84:
-        0xFEF7, // ARABIC LIGATURE LAM WITH ALEF WITH HAMZA ABOVE ISOLATED FORM
-    0xFE88:
-        0xFEF9, // ARABIC LIGATURE LAM WITH ALEF WITH HAMZA BELOW ISOLATED FORM
+    0xFE82: 0xFEF5, // ARABIC LIGATURE LAM WITH ALEF WITH MADDA ABOVE ISOLATED FORM
+    0xFE84: 0xFEF7, // ARABIC LIGATURE LAM WITH ALEF WITH HAMZA ABOVE ISOLATED FORM
+    0xFE88: 0xFEF9, // ARABIC LIGATURE LAM WITH ALEF WITH HAMZA BELOW ISOLATED FORM
     0xFE8E: 0xFEFB // ARABIC LIGATURE LAM WITH ALEF ISOLATED FORM
   },
   0xFEE0: <int, int>{
@@ -194,9 +181,7 @@ bool _isArabicLetter(int letter) {
 }
 
 bool _isArabicEndLetter(int letter) {
-  return _isArabicLetter(letter) &&
-      _isInArabicSubstitutionA(letter) &&
-      _arabicSubstitionA[letter].length <= 2;
+  return _isArabicLetter(letter) && _isInArabicSubstitutionA(letter) && _arabicSubstitionA[letter].length <= 2;
 }
 
 bool _isArabicAlfLetter(int letter) {
@@ -204,15 +189,11 @@ bool _isArabicAlfLetter(int letter) {
 }
 
 bool _arabicLetterHasFinalForm(int letter) {
-  return _isArabicLetter(letter) &&
-      _isInArabicSubstitutionA(letter) &&
-      (_arabicSubstitionA[letter].length >= 2);
+  return _isArabicLetter(letter) && _isInArabicSubstitutionA(letter) && (_arabicSubstitionA[letter].length >= 2);
 }
 
 bool _arabicLetterHasMedialForm(int letter) {
-  return _isArabicLetter(letter) &&
-      _isInArabicSubstitutionA(letter) &&
-      _arabicSubstitionA[letter].length == 4;
+  return _isArabicLetter(letter) && _isInArabicSubstitutionA(letter) && _arabicSubstitionA[letter].length == 4;
 }
 
 bool _isArabicDiacritic(int letter) {
@@ -339,11 +320,7 @@ Iterable<String> _parse(String text) sync* {
         newWord.insert(0, _arabicDiacritics[currentLetter]!);
         continue;
       }
-      final nextLetter = word
-          .split('')
-          .skip(j + 1)
-          .map((String e) => e.codeUnitAt(0))
-          .firstWhere(
+      final nextLetter = word.split('').skip(j + 1).map((String e) => e.codeUnitAt(0)).firstWhere(
             (int element) => !_isArabicDiacritic(element),
             orElse: () => 0,
           );
@@ -386,14 +363,19 @@ Iterable<String> _parse(String text) sync* {
   }
   // if notArabicWords.length != 0, that means all sentence doesn't contain Arabic.
   for (var i = 0; i < notArabicWords.length; i++) {
-    yield String.fromCharCodes(notArabicWords[i]);
-    if (i != notArabicWords.length - 1) {
+    if (!first) {
       yield ' ';
     }
+    yield String.fromCharCodes(notArabicWords[i]);
   }
 }
 
 /// Apply Arabic shape substitutions
 String convert(String input) {
-  return List<String>.from(_parse(input)).join('');
+  final lines = input.split('\n');
+  final parsed = <String>[];
+  for (var i = 0; i < lines.length; i++) {
+    parsed.addAll([..._parse(lines[i]), if (i != lines.length - 1) '\n']);
+  }
+  return parsed.join();
 }

--- a/pdf/lib/src/pdf/font/arabic.dart
+++ b/pdf/lib/src/pdf/font/arabic.dart
@@ -390,6 +390,7 @@ Iterable<String> _parse(String text) sync* {
       yield ' ';
     }
     yield String.fromCharCodes(notArabicWords[i]);
+
   }
 }
 
@@ -398,6 +399,9 @@ String convert(String input) {
   final lines = input.split('\n');
   final parsed = <String>[];
   for (var i = 0; i < lines.length; i++) {
+    if(lines[i].isEmpty) {
+      continue;
+    }
     parsed.addAll([..._parse(lines[i]), if (i != lines.length - 1) '\n']);
   }
   return parsed.join();

--- a/pdf/lib/src/pdf/font/arabic.dart
+++ b/pdf/lib/src/pdf/font/arabic.dart
@@ -24,7 +24,12 @@ const Map<int, dynamic> _arabicSubstitionA = <int, dynamic>{
   0x0623: <int>[1571, 0xFE84], // ARABIC LETTER ALEF WITH HAMZA ABOVE
   0x0624: <int>[1572, 0xFE86], // ARABIC LETTER WAW WITH HAMZA ABOVE
   0x0625: <int>[1573, 0xFE88], // ARABIC LETTER ALEF WITH HAMZA BELOW
-  0x0626: <int>[1574, 0xFE8A, 0xFE8B, 0xFE8C], // ARABIC LETTER YEH WITH HAMZA ABOVE
+  0x0626: <int>[
+    1574,
+    0xFE8A,
+    0xFE8B,
+    0xFE8C
+  ], // ARABIC LETTER YEH WITH HAMZA ABOVE
   0x0627: <int>[1575, 0xFE8E], // ARABIC LETTER ALEF
   0x0628: <int>[1576, 0xFE90, 0xFE91, 0xFE92], // ARABIC LETTER BEH
   0x0629: <int>[1577, 0xFE94], // ARABIC LETTER TEH MARBUTA
@@ -82,7 +87,12 @@ const Map<int, dynamic> _arabicSubstitionA = <int, dynamic>{
   0x06B3: <int>[0xFB96, 0xFB97, 0xFB98, 0xFB99], // ARABIC LETTER GUEH
   0x06BA: <int>[0xFB9E, 0xFB9F], // ARABIC LETTER NOON GHUNNA
   0x06BB: <int>[0xFBA0, 0xFBA1, 0xFBA2, 0xFBA3], // ARABIC LETTER RNOON
-  0x06BE: <int>[0xFBAA, 0xFBAB, 0xFBAC, 0xFBAD], // ARABIC LETTER HEH DOACHASHMEE
+  0x06BE: <int>[
+    0xFBAA,
+    0xFBAB,
+    0xFBAC,
+    0xFBAD
+  ], // ARABIC LETTER HEH DOACHASHMEE
   0x06C0: <int>[0xFBA4, 0xFBA5], // ARABIC LETTER HEH WITH YEH ABOVE
   0x06C1: <int>[0xFBA6, 0xFBA7, 0xFBA8, 0xFBA9], // ARABIC LETTER HEH GOAL
   0x06C5: <int>[0xFBE0, 0xFBE1], // ARABIC LETTER KIRGHIZ OE
@@ -116,9 +126,12 @@ const Map<int, dynamic> _diacriticLigatures = <int, dynamic>{
 
 const Map<int, dynamic> _ligatures = <int, dynamic>{
   0xFEDF: <int, int>{
-    0xFE82: 0xFEF5, // ARABIC LIGATURE LAM WITH ALEF WITH MADDA ABOVE ISOLATED FORM
-    0xFE84: 0xFEF7, // ARABIC LIGATURE LAM WITH ALEF WITH HAMZA ABOVE ISOLATED FORM
-    0xFE88: 0xFEF9, // ARABIC LIGATURE LAM WITH ALEF WITH HAMZA BELOW ISOLATED FORM
+    0xFE82:
+        0xFEF5, // ARABIC LIGATURE LAM WITH ALEF WITH MADDA ABOVE ISOLATED FORM
+    0xFE84:
+        0xFEF7, // ARABIC LIGATURE LAM WITH ALEF WITH HAMZA ABOVE ISOLATED FORM
+    0xFE88:
+        0xFEF9, // ARABIC LIGATURE LAM WITH ALEF WITH HAMZA BELOW ISOLATED FORM
     0xFE8E: 0xFEFB // ARABIC LIGATURE LAM WITH ALEF ISOLATED FORM
   },
   0xFEE0: <int, int>{
@@ -181,7 +194,9 @@ bool _isArabicLetter(int letter) {
 }
 
 bool _isArabicEndLetter(int letter) {
-  return _isArabicLetter(letter) && _isInArabicSubstitutionA(letter) && _arabicSubstitionA[letter].length <= 2;
+  return _isArabicLetter(letter) &&
+      _isInArabicSubstitutionA(letter) &&
+      _arabicSubstitionA[letter].length <= 2;
 }
 
 bool _isArabicAlfLetter(int letter) {
@@ -189,11 +204,15 @@ bool _isArabicAlfLetter(int letter) {
 }
 
 bool _arabicLetterHasFinalForm(int letter) {
-  return _isArabicLetter(letter) && _isInArabicSubstitutionA(letter) && (_arabicSubstitionA[letter].length >= 2);
+  return _isArabicLetter(letter) &&
+      _isInArabicSubstitutionA(letter) &&
+      (_arabicSubstitionA[letter].length >= 2);
 }
 
 bool _arabicLetterHasMedialForm(int letter) {
-  return _isArabicLetter(letter) && _isInArabicSubstitutionA(letter) && _arabicSubstitionA[letter].length == 4;
+  return _isArabicLetter(letter) &&
+      _isInArabicSubstitutionA(letter) &&
+      _arabicSubstitionA[letter].length == 4;
 }
 
 bool _isArabicDiacritic(int letter) {
@@ -320,7 +339,11 @@ Iterable<String> _parse(String text) sync* {
         newWord.insert(0, _arabicDiacritics[currentLetter]!);
         continue;
       }
-      final nextLetter = word.split('').skip(j + 1).map((String e) => e.codeUnitAt(0)).firstWhere(
+      final nextLetter = word
+          .split('')
+          .skip(j + 1)
+          .map((String e) => e.codeUnitAt(0))
+          .firstWhere(
             (int element) => !_isArabicDiacritic(element),
             orElse: () => 0,
           );

--- a/pdf/pubspec.yaml
+++ b/pdf/pubspec.yaml
@@ -3,7 +3,7 @@ description: A pdf producer for Dart. It can create pdf files for both web or fl
 homepage: https://github.com/DavBfr/dart_pdf/tree/master/pdf
 repository: https://github.com/DavBfr/dart_pdf
 issue_tracker: https://github.com/DavBfr/dart_pdf/issues
-version: 3.7.3
+version: 3.7.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/pdf/test/arabic_test.dart
+++ b/pdf/test/arabic_test.dart
@@ -17,7 +17,6 @@
 import 'dart:io';
 
 import 'package:pdf/src/pdf/font/arabic.dart' as arabic;
-import 'package:pdf/src/pdf/font/arabic.dart';
 import 'package:pdf/widgets.dart';
 import 'package:test/test.dart';
 

--- a/pdf/test/arabic_test.dart
+++ b/pdf/test/arabic_test.dart
@@ -41,7 +41,7 @@ void main() {
     RichText.debug = true;
     pdf = Document();
 
-    arabicFont = loadFont('/Users/milad/development/projects/dart_pdf/pdf/test/hacen-tunisia.ttf');
+    arabicFont = loadFont('test/fonts/hacen-tunisia.ttf');
     style = TextStyle(font: arabicFont, fontSize: 30);
   });
 

--- a/pdf/test/arabic_test.dart
+++ b/pdf/test/arabic_test.dart
@@ -17,6 +17,7 @@
 import 'dart:io';
 
 import 'package:pdf/src/pdf/font/arabic.dart' as arabic;
+import 'package:pdf/src/pdf/font/arabic.dart';
 import 'package:pdf/widgets.dart';
 import 'package:test/test.dart';
 
@@ -41,14 +42,13 @@ void main() {
     RichText.debug = true;
     pdf = Document();
 
-    arabicFont = loadFont('hacen-tunisia.ttf');
+    arabicFont = loadFont('/Users/milad/development/projects/dart_pdf/pdf/test/hacen-tunisia.ttf');
     style = TextStyle(font: arabicFont, fontSize: 30);
   });
 
   test('Arabic Diacritics', () {
     final a = ArabicText('السلام', <int>[1605, 65276, 65204, 65247, 1575]);
-    final b = ArabicText('السَلَاْمٌ',
-        <int>[1612, 1605, 1618, 1614, 65276, 1614, 65204, 65247, 1575]);
+    final b = ArabicText('السَلَاْمٌ', <int>[1612, 1605, 1618, 1614, 65276, 1614, 65204, 65247, 1575]);
 
     expect(
       arabic.convert(a.original).codeUnits,
@@ -158,22 +158,7 @@ void main() {
         1614,
         65251
       ]),
-      ArabicText('اللغات السامية', <int>[
-        1578,
-        65166,
-        65232,
-        65248,
-        65247,
-        1575,
-        32,
-        65172,
-        65268,
-        65251,
-        65166,
-        65204,
-        65247,
-        1575
-      ]),
+      ArabicText('اللغات السامية', <int>[1578, 65166, 65232, 65248, 65247, 1575, 32, 65172, 65268, 65251, 65166, 65204, 65247, 1575]),
       ArabicText('العربية لغةٌ رسميةٌ في', <int>[
         65172,
         65268,
@@ -439,7 +424,7 @@ void main() {
         65176,
         65252,
         65247,
-        1575
+        1575,
       ]),
     ];
 
@@ -484,6 +469,36 @@ void main() {
                   'القهوة مشروب يعد من بذور الب المحمصة، وينمو في أكثر من 70 لداً. خصوصاً في المناطق الاستوائية في أمريكا الشمالية والجنوبية وجنوب شرق آسيا وشبه القارة الهندية وأفريقيا. ويقال أن البن الأخضر هو ثاني أكثر السلع تداولاً في العالم بعد النفط الخام.',
               style: TextStyle(
                 fontSize: 20,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ));
+  });
+
+  test('Text Widgets, Mixed Arabic and Latin words should be rendered in order ', () {
+    pdf.addPage(Page(
+      textDirection: TextDirection.rtl,
+      build: (Context context) => RichText(
+        text: TextSpan(
+          text: 'النصوص ثنائية الإتجاه Bidirectional Text\n',
+          style: TextStyle(
+            font: arabicFont,
+            fontSize: 30,
+          ),
+          children: const <TextSpan>[
+            TextSpan(
+              text: r'''
+الكلمات اللاتينية المضافة إلى نص عربي يجب أن توضع في الترتيب الصحيح Right Order مهما كان موضعها في النص.
+At the Beginning of the sentence في بداية الجملة
+أو في منتصفها In the middle of the sentence حيث يكون بعدها كلام عربي
+أو في نهاية النص At the end of the sentence
+أيضا ترتيب الأرقام والرموز يجب 1 أن 2 يكون 3 صحيحاً$.
+ولا ننسى أيضا فواصل السطور Line breakers حيث وجودها في موضعها الصحيح مهم جدا في النصوص ثنائية الاتجاه Bidirectional
+              ''',
+              style: TextStyle(
+                fontSize: 18,
               ),
             ),
           ],


### PR DESCRIPTION
This fixes this issue  #739  including proper handling of line breakers  in Bidirectional text

screenshot form the Arabic generated test pdf
![Screen Shot 2022-03-30 at 4 49 27 PM](https://user-images.githubusercontent.com/55059449/160850688-8901f86a-d162-4496-a875-81c0f26c5e36.png)
