### PR TITLE
Set cutLength to be currentSize.height

### DIFF
--- a/printing/ios/Classes/PrintJob.swift
+++ b/printing/ios/Classes/PrintJob.swift
@@ -31,7 +31,8 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
     private var orientation: UIPrintInfo.Orientation?
     private let semaphore = DispatchSemaphore(value: 0)
     private var dynamic = false
-
+    private var currentSize: CGSize?
+    
     public init(printing: PrintingPlugin, index: Int) {
         self.printing = printing
         self.index = index
@@ -134,7 +135,17 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
         printing.onCompleted(printJob: self, completed: completed, error: error?.localizedDescription as NSString?)
     }
 
+    public func printInteractionController(_ printInteractionController: UIPrintInteractionController, cutLengthFor paper: UIPrintPaper) -> CGFloat {
+        if currentSize == nil{
+            return  paper.paperSize.height
+        }
+
+        return currentSize!.height
+       
+    }
+    
     func printPdf(name: String, withPageSize size: CGSize, andMargin margin: CGRect, withPrinter printerID: String?, dynamically dyn: Bool) {
+        currentSize = size
         dynamic = dyn
         let printing = UIPrintInteractionController.isPrintingAvailable
         if !printing {


### PR DESCRIPTION
- If the `currentSize` is set, set `cutLengthFor` to be the `currentSize.height`, else default to the `paper.paperSize.height`.

See [this ](https://github.com/DavBfr/dart_pdf/issues/999) issue for details. 

TLDR: There was an issue with receipt printer roll paper, where the print job would use as much paper as it could even if the `PdfPageFormat` was set. This should fix that issue. 

