### PR TITLE
Clean up memory usage when using pdf.js

### DIFF
--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -280,6 +280,7 @@ class PrintingPlugin extends PrintingPlatform {
         data.toBytes(),
       );
     }
+    t.destroy();
   }
 }
 

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -259,7 +259,7 @@ class PrintingPlugin extends PrintingPlatform {
         ..viewport = viewport;
 
       await promiseToFuture<void>(page.render(renderContext).promise);
-
+      
       // Convert the image to PNG
       final completer = Completer<void>();
       final blob = await canvas.toBlob();
@@ -279,6 +279,7 @@ class PrintingPlugin extends PrintingPlatform {
         canvas.height!,
         data.toBytes(),
       );
+      page.cleanup();
     }
     t.destroy();
   }

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -259,7 +259,7 @@ class PrintingPlugin extends PrintingPlatform {
         ..viewport = viewport;
 
       await promiseToFuture<void>(page.render(renderContext).promise);
-      
+
       // Convert the image to PNG
       final completer = Completer<void>();
       final blob = await canvas.toBlob();

--- a/printing/lib/src/pdfjs.dart
+++ b/printing/lib/src/pdfjs.dart
@@ -58,6 +58,7 @@ class PdfJsDoc {
 class PdfJsPage {
   external PdfJsViewport getViewport(Settings data);
   external PdfJsRender render(Settings data);
+  external bool cleanup();
 }
 
 @anonymous

--- a/printing/lib/src/pdfjs.dart
+++ b/printing/lib/src/pdfjs.dart
@@ -43,6 +43,7 @@ class Settings {
 @JS()
 class PdfJsDocLoader {
   external Future<PdfJsDoc> get promise;
+  external Future<void> destroy();
 }
 
 @anonymous


### PR DESCRIPTION
These changes are only relevant for web

- Calls the destroy method for the PDF document
- Calls the cleanup method for each PDF page

Potential related issues:
https://github.com/DavBfr/dart_pdf/issues/1019