### PR TITLE
Fix exif orientation

### DIFF
--- a/pdf/lib/src/pdf/exif.dart
+++ b/pdf/lib/src/pdf/exif.dart
@@ -112,7 +112,12 @@ class PdfJpegInfo {
     }
 
     try {
-      return PdfImageOrientation.values[tags![PdfExifTag.Orientation] - 1];
+      final int index = tags![PdfExifTag.Orientation] - 1;
+      const orientations = PdfImageOrientation.values;
+      if (index >= 0 && index < orientations.length) {
+        return orientations[index];
+      }
+      return PdfImageOrientation.topLeft;
     } on RangeError {
       return PdfImageOrientation.topLeft;
     }


### PR DESCRIPTION
fixes https://github.com/DavBfr/dart_pdf/issues/1078

It seems that RangeError is not working on Web in release and profile mode.
See https://github.com/flutter/flutter/issues/101456

To enable it, need to use an optimization level argument when building the web build.