### PR TITLE
Added mounted check for setState in printing>preview>raster

### DIFF
--- a/printing/lib/src/preview/raster.dart
+++ b/printing/lib/src/preview/raster.dart
@@ -139,14 +139,17 @@ mixin PdfPreviewRaster on State<PdfPreviewCustom> {
         context: ErrorDescription('while generating a PDF'),
         informationCollector: collector,
       ));
-      setState(() {
-        error = exception;
-        _rastering = false;
-      });
+      if (mounted) {
+        setState(() {
+          error = exception;
+          _rastering = false;
+        });
+      }
+
       return;
     }
 
-    if (error != null) {
+    if (error != null && mounted) {
       setState(() {
         error = null;
       });
@@ -182,7 +185,10 @@ mixin PdfPreviewRaster on State<PdfPreviewCustom> {
             pageMargin: widget.previewPageMargin,
           );
         }
-        setState(() {});
+
+        if (mounted) {
+          setState(() {});
+        }
 
         pageNum++;
       }
@@ -191,7 +197,9 @@ mixin PdfPreviewRaster on State<PdfPreviewCustom> {
         pages[index].image.evict();
       }
       pages.removeRange(pageNum, pages.length);
-      setState(() {});
+      if (mounted) {
+        setState(() {});
+      }
     } catch (exception, stack) {
       InformationCollector? collector;
 
@@ -210,9 +218,11 @@ mixin PdfPreviewRaster on State<PdfPreviewCustom> {
         informationCollector: collector,
       ));
 
-      setState(() {
-        error = exception;
-      });
+      if (mounted) {
+        setState(() {
+          error = exception;
+        });
+      }
     }
 
     _rastering = false;

--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -6,7 +6,7 @@ description: >
 homepage: https://github.com/DavBfr/dart_pdf/tree/master/printing
 repository: https://github.com/DavBfr/dart_pdf
 issue_tracker: https://github.com/DavBfr/dart_pdf/issues
-version: 5.9.1
+version: 5.9.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
It throws an error when I leave the screen that has PdfPreview when it is not done loading. So I fixed it by checking if mounted before calling setState.