### PR TITLE
Add showsCopies option to macOS print panel

### DIFF
--- a/printing/macos/Classes/PrintJob.swift
+++ b/printing/macos/Classes/PrintJob.swift
@@ -159,14 +159,14 @@ public class PrintJob: NSView, NSSharingServicePickerDelegate {
         // The custom print view
         printOperation = NSPrintOperation(view: self, printInfo: printInfo)
         printOperation!.jobTitle = name
-        printOperation!.printPanel.options = [.showsPreview]
+        printOperation!.printPanel.options = [.showsPreview, .showsCopies]
         if printer != nil {
             printOperation!.showsPrintPanel = false
             printOperation!.showsProgressPanel = false
         }
 
         if dynamic {
-            printOperation!.printPanel.options = [.showsPreview, .showsPaperSize, .showsOrientation]
+            printOperation!.printPanel.options = [.showsPreview, .showsPaperSize, .showsOrientation, .showsCopies]
             printOperation!.runModal(for: _window!, delegate: self, didRun: #selector(printOperationDidRun(printOperation:success:contextInfo:)), contextInfo: nil)
             return
         }


### PR DESCRIPTION
This adds the `.showCopies` option to `printOperation!.printPanel.options` on macOS platform's print window

Fixes #1083 