### PR TITLE
Adds option to disable the scrolling behaviour of the preview widget for use inside other scrollables

### DIFF
--- a/printing/lib/src/preview/custom.dart
+++ b/printing/lib/src/preview/custom.dart
@@ -41,6 +41,8 @@ class PdfPreviewCustom extends StatefulWidget {
     this.shouldRepaint = false,
     this.loadingWidget,
     this.dpi,
+    this.scrollPhysics,
+    this.shrinkWrap = false,
   }) : super(key: key);
 
   /// Pdf paper page format
@@ -57,6 +59,12 @@ class PdfPreviewCustom extends StatefulWidget {
 
   /// Decoration of scrollView
   final Decoration? scrollViewDecoration;
+
+  /// Whether the scrollView should be shrinkwrapped
+  final bool shrinkWrap;
+
+  /// The physics for the scrollView - e.g. use this to disable scrolling inside a scrollable
+  final ScrollPhysics? scrollPhysics;
 
   /// Decoration of PdfPreviewPage
   final Decoration? pdfPreviewPageDecoration;
@@ -177,6 +185,8 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
 
     return ListView.builder(
       controller: scrollController,
+      shrinkWrap: widget.shrinkWrap,
+      physics: widget.scrollPhysics,
       padding: widget.padding,
       itemCount: pages.length,
       itemBuilder: (BuildContext context, int index) => GestureDetector(


### PR DESCRIPTION
* Adds option to shrinkwrap preview and set scrollablePhysics to be able to disable the scrollView inside another scrollable
* This is useful when we want to display the pdf inside a Material stepper which provides its own scrollable surface, or if we want to embed the PDF preview inside another ListView or the like