### PR TITLE
Resolve driver compatibility issues

### DIFF
--- a/printing/windows/print_job.cpp
+++ b/printing/windows/print_job.cpp
@@ -81,13 +81,21 @@ bool PrintJob::printPdf(const std::string& name,
                         bool usePrinterSettings) {
   documentName = name;
 
-  auto dm = static_cast<DEVMODE*>(GlobalAlloc(0, sizeof(DEVMODE)));
+  std::size_t dmSize = sizeof(DEVMODE);
+  std::size_t dmExtra = 0;
+
+  if(!printer.empty()){
+    dmExtra = DeviceCapabilities(fromUtf8(printer).c_str(), NULL, DC_EXTRA, NULL, NULL);
+  }
+
+  auto dm = static_cast<DEVMODE*>(GlobalAlloc(0, dmSize + dmExtra));
 
   if (usePrinterSettings) {
     dm = nullptr;  // to use default driver config
   } else {
     ZeroMemory(dm, sizeof(DEVMODE));
-    dm->dmSize = sizeof(DEVMODE);
+    dm->dmSize = (WORD)dmSize;
+    dm->dmDriverExtra = (WORD)dmExtra;
     dm->dmFields =
         DM_ORIENTATION | DM_PAPERSIZE | DM_PAPERLENGTH | DM_PAPERWIDTH;
     dm->dmPaperSize = 0;


### PR DESCRIPTION
**Initial issue**
With some drivers (Sharp, Lexmark) the flutter app was crashing when attempting to print (with `usePrinterSettings=false`)

**Fix**
The size of the driver specific part of DEVMODE was not definied.