### PR TITLE
fix RTL Table View

### DIFF
--- a/pdf/lib/src/widgets/table.dart
+++ b/pdf/lib/src/widgets/table.dart
@@ -683,3 +683,18 @@ class Table extends Widget with SpanningWidget {
     }
   }
 }
+
+extension RtlList<E> on List<E> {
+  List<E> showRTL() {
+    var result = <E>[];
+    for (var i = length - 1; i >= 0; i--) {
+      dynamic element;
+      element = elementAt(i);
+      if (element is List) {
+        element = element.showRTL();
+      }
+      result.add(element);
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
to fix RTL Table View that show content table from left to right instead of right to left
i add an option to show RTL content in table as proper RTL direction
just by adding **.showRTL()** in _headers_ & _data_ .

example code:
```
final table = pw.Table.fromTextArray(
    headers: tableHeaders.showRTL(),
    data: tableData.showRTL(),
...
```
before add showRTL:
![01](https://user-images.githubusercontent.com/70948326/189477011-d34b297d-31fa-4de6-bd17-ce60876714c4.png)

after add showRTL:
![02](https://user-images.githubusercontent.com/70948326/189476899-48b1a606-a2ae-438b-a114-bfb1e591fcfe.png)


