### PR TITLE
Fix canChangeOrientation option not appearing bug

### DIFF
--- a/printing/lib/src/preview/pdf_preview.dart
+++ b/printing/lib/src/preview/pdf_preview.dart
@@ -282,12 +282,13 @@ class _PdfPreviewState extends State<PdfPreview> {
       actions.add(PdfPageFormatAction(
         pageFormats: widget.pageFormats,
       ));
-
-      if (widget.useActions && widget.canChangeOrientation) {
-        // ignore: prefer_const_constructors
-        actions.add(PdfPageOrientationAction());
-      }
     }
+    
+    if (widget.useActions && widget.canChangeOrientation) {
+      // ignore: prefer_const_constructors
+      actions.add(PdfPageOrientationAction());
+    }
+    
 
     widget.actions?.forEach(actions.add);
 


### PR DESCRIPTION
Fixed the issue where canChangePageFormat also disabled canChangeOrientation.