### PR TITLE
Update table.dart pw.Table.fromTextArray() to support RTL

### DIFF
--- a/pdf/lib/src/widgets/table.dart
+++ b/pdf/lib/src/widgets/table.dart
@@ -262,6 +262,8 @@ class Table extends Widget with SpanningWidget {
     Alignment headerAlignment = Alignment.center,
     Map<int, Alignment>? headerAlignments,
     TextStyle? headerStyle,
+    TextDirection? headerDirection,
+    TextDirection? tableDirection,
     OnCellFormat? headerFormat,
     TableBorder? border = const TableBorder(
       left: BorderSide(),
@@ -312,6 +314,8 @@ class Table extends Widget with SpanningWidget {
                   ? cell.toString()
                   : headerFormat(tableRow.length, cell),
               style: headerStyle,
+              textDirection: headerDirection,
+              //   textAlign:
             ),
           ),
         );
@@ -344,6 +348,7 @@ class Table extends Widget with SpanningWidget {
                     : headerFormat(tableRow.length, cell),
                 style: headerStyle,
                 textAlign: textAlign,
+                textDirection: tableDirection,
               ),
             ),
           );
@@ -366,6 +371,7 @@ class Table extends Widget with SpanningWidget {
                     : cellFormat(tableRow.length, cell),
                 style: isOdd ? oddCellStyle : cellStyle,
                 textAlign: textAlign,
+                textDirection: tableDirection,
               ),
             ),
           );


### PR DESCRIPTION
make the method 
pw.Table.fromTextArray()
work with rtl and Arabic
by adding these properties
   headerDirection: pw.TextDirection.rtl,
   tableDirection: pw.TextDirection.rtl,
you also need to use right font that support arabic 

