### PR TITLE
 Add custom pages builder to PdfPreview widget

### DIFF
--- a/printing/lib/src/preview/custom.dart
+++ b/printing/lib/src/preview/custom.dart
@@ -22,7 +22,12 @@ import 'package:pdf/pdf.dart';
 import '../callback.dart';
 import '../printing.dart';
 import '../printing_info.dart';
+import 'page.dart';
 import 'raster.dart';
+/// Custom widget builder that's used for custom
+/// rasterized pdf pages rendering
+typedef CustomPdfPagesBuilder = Widget Function(
+    BuildContext context, List<PdfPreviewPageData> pages);
 
 /// Flutter widget that uses the rasterized pdf pages to display a document.
 class PdfPreviewCustom extends StatefulWidget {
@@ -43,6 +48,7 @@ class PdfPreviewCustom extends StatefulWidget {
     this.dpi,
     this.scrollPhysics,
     this.shrinkWrap = false,
+    this.pagesBuilder,
   }) : super(key: key);
 
   /// Pdf paper page format
@@ -90,6 +96,10 @@ class PdfPreviewCustom extends StatefulWidget {
   /// The rendering dots per inch resolution
   /// If not provided, this value is calculated.
   final double? dpi;
+
+  /// clients can pass this builder to render
+  /// their own pages.
+  final CustomPdfPagesBuilder? pagesBuilder;
 
   @override
   PdfPreviewCustomState createState() => PdfPreviewCustomState();
@@ -183,6 +193,9 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
           );
     }
 
+    if (widget.pagesBuilder != null) {
+      return widget.pagesBuilder!(context, pages);
+    }
     return ListView.builder(
       controller: scrollController,
       shrinkWrap: widget.shrinkWrap,
@@ -197,7 +210,11 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
             transformationController.value.setIdentity();
           });
         },
-        child: pages[index],
+        child: PdfPreviewPage(
+          pageData: pages[index],
+          pdfPreviewPageDecoration: widget.pdfPreviewPageDecoration,
+          pageMargin: widget.previewPageMargin,
+        ),
       ),
     );
   }
@@ -212,7 +229,13 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
       child: InteractiveViewer(
         transformationController: transformationController,
         maxScale: 5,
-        child: Center(child: pages[preview!]),
+        child: Center(
+          child: PdfPreviewPage(
+            pageData: pages[preview!],
+            pdfPreviewPageDecoration: widget.pdfPreviewPageDecoration,
+            pageMargin: widget.previewPageMargin,
+          ),
+        ),
       ),
     );
   }

--- a/printing/lib/src/preview/page.dart
+++ b/printing/lib/src/preview/page.dart
@@ -15,25 +15,58 @@
  */
 
 import 'package:flutter/material.dart';
+/// A class that holds rasterized pdf data
+class PdfPreviewPageData {
+  /// Default constructor
+  const PdfPreviewPageData({
+    required this.image,
+    required this.width,
+    required this.height,
+  });
+
+  /// rasterized pdf image provider
+  final ImageProvider image;
+  /// rasterized image width
+  final int width;
+  /// rasterized image height
+  final int height;
+
+   /// returns with to height aspect ratio
+  double get aspectRatio {
+    if (height != 0.0)
+      return width / height;
+    if (width > 0.0)
+      return double.infinity;
+    if (width < 0.0)
+      return double.negativeInfinity;
+    return 0.0;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PdfPreviewPageData &&
+          runtimeType == other.runtimeType &&
+          image == other.image &&
+          width == other.width &&
+          height == other.height;
+
+  @override
+  int get hashCode => image.hashCode ^ width.hashCode ^ height.hashCode;
+}
 
 /// Represents one PDF page
 class PdfPreviewPage extends StatelessWidget {
   /// Create a PDF page widget
   const PdfPreviewPage({
     Key? key,
-    required this.image,
-    required this.width,
-    required this.height,
+    required this.pageData,
     this.pdfPreviewPageDecoration,
     this.pageMargin,
   }) : super(key: key);
 
   /// Image representing the content of the page
-  final ImageProvider image;
-
-  final int width;
-
-  final int height;
+  final PdfPreviewPageData pageData;
 
   /// Decoration around the page
   final Decoration? pdfPreviewPageDecoration;
@@ -69,9 +102,9 @@ class PdfPreviewPage extends StatelessWidget {
             ],
           ),
       child: AspectRatio(
-        aspectRatio: width / height,
+        aspectRatio: pageData.aspectRatio,
         child: Image(
-          image: image,
+          image: pageData.image,
           fit: BoxFit.cover,
         ),
       ),

--- a/printing/lib/src/preview/page.dart
+++ b/printing/lib/src/preview/page.dart
@@ -33,12 +33,15 @@ class PdfPreviewPageData {
 
    /// returns with to height aspect ratio
   double get aspectRatio {
-    if (height != 0.0)
+    if (height != 0.0) {
       return width / height;
-    if (width > 0.0)
+    }
+    if (width > 0.0) {
       return double.infinity;
-    if (width < 0.0)
+    }
+    if (width < 0.0) {
       return double.negativeInfinity;
+    }
     return 0.0;
   }
 

--- a/printing/lib/src/preview/pdf_preview.dart
+++ b/printing/lib/src/preview/pdf_preview.dart
@@ -61,7 +61,43 @@ class PdfPreview extends StatefulWidget {
     this.loadingWidget,
     this.onPageFormatChanged,
     this.dpi,
-  }) : super(key: key);
+  })  : _pagesBuilder = null,
+        super(key: key);
+
+  const PdfPreview.builder({
+    Key? key,
+    required this.build,
+    this.initialPageFormat,
+    this.allowPrinting = true,
+    this.allowSharing = true,
+    this.maxPageWidth,
+    this.canChangePageFormat = true,
+    this.canChangeOrientation = true,
+    this.canDebug = true,
+    this.actions,
+    this.pageFormats = _defaultPageFormats,
+    this.onError,
+    this.onPrinted,
+    this.onPrintError,
+    this.onShared,
+    this.scrollViewDecoration,
+    this.pdfPreviewPageDecoration,
+    this.pdfFileName,
+    this.useActions = true,
+    this.pages,
+    this.dynamicLayout = true,
+    this.shareActionExtraBody,
+    this.shareActionExtraSubject,
+    this.shareActionExtraEmails,
+    this.previewPageMargin,
+    this.padding,
+    this.shouldRepaint = false,
+    this.loadingWidget,
+    this.onPageFormatChanged,
+    this.dpi,
+    required CustomPdfPagesBuilder pagesBuilder,
+  })  : _pagesBuilder = pagesBuilder,
+        super(key: key);
 
   static const _defaultPageFormats = <String, PdfPageFormat>{
     'A4': PdfPageFormat.a4,
@@ -162,6 +198,10 @@ class PdfPreview extends StatefulWidget {
   /// The rendering dots per inch resolution
   /// If not provided, this value is calculated.
   final double? dpi;
+
+  /// clients can pass this builder to render
+  /// their own pages.
+  final CustomPdfPagesBuilder? _pagesBuilder;
 
   @override
   _PdfPreviewState createState() => _PdfPreviewState();
@@ -331,6 +371,7 @@ class _PdfPreviewState extends State<PdfPreview> {
                 previewPageMargin: widget.previewPageMargin,
                 scrollViewDecoration: widget.scrollViewDecoration,
                 shouldRepaint: widget.shouldRepaint,
+                pagesBuilder: widget._pagesBuilder,
                 dpi: widget.dpi,
               );
             }),

--- a/printing/lib/src/preview/pdf_preview.dart
+++ b/printing/lib/src/preview/pdf_preview.dart
@@ -26,6 +26,7 @@ import 'controller.dart';
 import 'custom.dart';
 
 export 'custom.dart';
+export 'page.dart' show PdfPreviewPageData;
 
 /// Flutter widget that uses the rasterized pdf pages to display a document.
 class PdfPreview extends StatefulWidget {

--- a/printing/lib/src/preview/raster.dart
+++ b/printing/lib/src/preview/raster.dart
@@ -38,7 +38,7 @@ mixin PdfPreviewRaster on State<PdfPreviewCustom> {
   PdfPageFormat get pageFormat => widget.pageFormat;
 
   /// Resulting pages
-  final pages = <PdfPreviewPage>[];
+  final pages = <PdfPreviewPageData>[];
 
   /// Printing subsystem information
   PrintingInfo? info;
@@ -167,23 +167,18 @@ mixin PdfPreviewRaster on State<PdfPreviewCustom> {
           _rastering = false;
           return;
         }
-
         if (pages.length <= pageNum) {
-          pages.add(PdfPreviewPage(
+          pages.add(PdfPreviewPageData(
             image: MemoryImage(await page.toPng()),
             width: page.width,
             height: page.height,
-            pdfPreviewPageDecoration: widget.pdfPreviewPageDecoration,
-            pageMargin: widget.previewPageMargin,
           ));
         } else {
           pages[pageNum].image.evict();
-          pages[pageNum] = PdfPreviewPage(
+          pages[pageNum] = PdfPreviewPageData(
             image: MemoryImage(await page.toPng()),
             width: page.width,
             height: page.height,
-            pdfPreviewPageDecoration: widget.pdfPreviewPageDecoration,
-            pageMargin: widget.previewPageMargin,
           );
         }
 


### PR DESCRIPTION
Hello @DavBfr 
This PR adds a custom pages builder to the existing `PdfPreview` widget without changes in the default behaviour.

 it's to be used to render custom pdf preview. e.g if I wanted something like the following: 
 
![Screen Shot 2022-11-16 at 1 29 14 PM](https://user-images.githubusercontent.com/55059449/202157194-5be1c8d5-8992-4887-abf6-0182b583cf9f.png)

I'd write something as simple as this 
```dart
PdfPreview.builder(
  build: (format) => _generatePdf(format, title),
  pagesBuilder: (context, pages) => Wrap(
    spacing: 8,
    runSpacing: 8,
    children: [
      for (final page in pages)
        Image(
          image: page.image,
          width: 300,
        )
    ],
  ),
 )
```