### PR TITLE
[printing][web]Support cmaps option

### DIFF
--- a/printing/README.md
+++ b/printing/README.md
@@ -43,14 +43,13 @@ for documentation.
    <true/>
    ```
 
-5. If you want to manually set the PdfJs library version for the web, a javascript
-   library and a small script has to be added to your `web/index.html` file, just
-   before `</head>`. Otherwise it is loaded automatically:
+5. If you want to manually set the PdfJs library version for the web, a small script 
+   has to be added to your `web/index.html` file, just before `</head>`.
+   Otherwise it is loaded automatically:
 
    ```html
-   <script src="//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.8.335/pdf.min.js"></script>
-   <script type="text/javascript">
-       pdfjsLib.GlobalWorkerOptions.workerSrc = "//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.8.335/pdf.worker.min.js";
+   <script>
+     var dartPdfJsVersion = "3.2.146";
    </script>
    ```
 

--- a/printing/example/lib/main.dart
+++ b/printing/example/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
 import 'package:printing/printing.dart';
+import 'package:printing_example/raster_check.dart';
 
 Future<void> main() async {
   runApp(const MyApp('Printing Demo'));
@@ -19,11 +20,41 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(title: Text(title)),
-        body: PdfPreview(
-          build: (format) => _generatePdf(format, title),
-        ),
+      home: Home(
+        title: title,
+      ),
+    );
+  }
+}
+
+class Home extends StatelessWidget {
+  const Home({
+    Key? key,
+    required this.title,
+  }) : super(key: key);
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title),
+        actions: [
+          IconButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const RasterCheck(),
+                ),
+              );
+            },
+            icon: const Icon(Icons.language),
+          ),
+        ],
+      ),
+      body: PdfPreview(
+        build: (format) => _generatePdf(format, title),
       ),
     );
   }

--- a/printing/example/lib/raster_check.dart
+++ b/printing/example/lib/raster_check.dart
@@ -1,0 +1,73 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:printing/printing.dart';
+
+class RasterCheck extends StatefulWidget {
+  const RasterCheck({Key? key}) : super(key: key);
+
+  @override
+  State<RasterCheck> createState() => _RasterCheckState();
+}
+
+class _RasterCheckState extends State<RasterCheck> {
+  /// PDF file's url
+  static const _url = '';
+
+  final _futurePdf = http.readBytes(Uri.parse(_url));
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Raster check'),
+      ),
+      body: FutureBuilder<Uint8List>(
+        future: _futurePdf,
+        builder: (context, snapshot) {
+          final error = snapshot.error;
+          if (error != null) {
+            return Center(
+              child: Text('$error'),
+            );
+          }
+
+          final data = snapshot.data;
+          if (data == null) {
+            return const Center(
+              child: CircularProgressIndicator(),
+            );
+          }
+
+          final image = Printing.raster(data).first.then(
+                (value) => value.toImage(),
+              );
+          return FutureBuilder<ui.Image>(
+            future: image,
+            builder: (context, snapshot) {
+              final error = snapshot.error;
+              if (error != null) {
+                return Center(
+                  child: Text('$error'),
+                );
+              }
+
+              final data = snapshot.data;
+              if (data == null) {
+                return const Center(
+                  child: CircularProgressIndicator(),
+                );
+              }
+
+              return RawImage(
+                image: data,
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/printing/example/pubspec.yaml
+++ b/printing/example/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   vector_math: ^2.1.0
   xml: ">=5.1.0 <7.0.0"
 
+  http: ^0.13.5
+
 dependency_overrides:
   pdf:
     path: ../../pdf

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -56,7 +56,11 @@ class PrintingPlugin extends PrintingPlatform {
         'typeof pdfjsLib !== "undefined" && pdfjsLib.GlobalWorkerOptions.workerSrc!="";'
       ]);
 
-  String get _pdfJsUrlBase => '$_pdfJsCdnPath@$_pdfJsVersion/';
+  String get _selectPdfJsVersion => js.context.hasProperty('dartPdfJsVersion')
+      ? js.context['dartPdfJsVersion']
+      : _pdfJsVersion;
+
+  String get _pdfJsUrlBase => '$_pdfJsCdnPath@$_selectPdfJsVersion/';
 
   Future<void> _initPlugin() async {
     await _loading.acquire();

--- a/printing/lib/src/pdfjs.dart
+++ b/printing/lib/src/pdfjs.dart
@@ -37,6 +37,8 @@ class Settings {
   external set scale(double value);
   external set canvasContext(CanvasRenderingContext2D value);
   external set viewport(PdfJsViewport value);
+  external set cMapUrl(String value);
+  external set cMapPacked(bool value);
 }
 
 @anonymous


### PR DESCRIPTION
I live in Japan and sometimes use Flutter Web to display PDF in Japanese. At this time, I need to set the option `cmaps` in pdf.js.
Since Android and iOS support PDF in Japanese (and other languages), I thought it would be nice to be able to support them on the web as well.

https://mozilla.github.io/pdf.js/api/draft/module-pdfjsLib.html

I also updated the code to allow different pdf.js versions to be specified and modified the README.
And, I added one screen so that we can check the raster processing in the example project; we can set the url of the PDF that needs `cmaps` to see it in action.

Thanks for the great library.