### PR TITLE
table data accepts Widgets as child

### DIFF
--- a/pdf/lib/src/widgets/table.dart
+++ b/pdf/lib/src/widgets/table.dart
@@ -338,7 +338,7 @@ class Table extends Widget with SpanningWidget {
               alignment: align,
               padding: headerPadding,
               constraints: BoxConstraints(minHeight: headerHeight),
-              child: Text(
+              child:cell is Widget? cell:  Text(
                 headerFormat == null
                     ? cell.toString()
                     : headerFormat(tableRow.length, cell),
@@ -360,7 +360,7 @@ class Table extends Widget with SpanningWidget {
               decoration: cellDecoration == null
                   ? null
                   : cellDecoration(tableRow.length, cell, rowNum),
-              child: Text(
+              child: cell is Widget? cell:  Text(
                 cellFormat == null
                     ? cell.toString()
                     : cellFormat(tableRow.length, cell),


### PR DESCRIPTION
Previously data on the table can accept the dynamic value and which was rendered with toString on the Text widget on the screen.  But I need to insert a small table inside the table cell so I changed this Cell on the table to accept any pdf Widgets or if the dynamic value is not a widget it automatically uses Text as previously with toString methods.