### PR TITLE
Replace `window` parameter of RenderView with `view`

### DIFF
--- a/printing/lib/src/widget_wrapper.dart
+++ b/printing/lib/src/widget_wrapper.dart
@@ -175,7 +175,7 @@ class WidgetWrapper extends pw.ImageProvider {
           size:
               Size(computedConstraints.maxWidth, computedConstraints.maxHeight),
           devicePixelRatio: view.devicePixelRatio),
-      window: view,
+      view: view,
     );
 
     final pipelineOwner = PipelineOwner()..rootNode = renderView;


### PR DESCRIPTION
On the latest master channel version we can find that this parameter's name in RenderView class has been changed from `window` to `view`. You can merge it on the next stable release or add this branch for those who are working on flutter's master channel.