### PR TITLE
Fix raster crash on iOS and MacOS

### DIFF
--- a/printing/ios/Classes/PrintJob.swift
+++ b/printing/ios/Classes/PrintJob.swift
@@ -32,7 +32,7 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
     private let semaphore = DispatchSemaphore(value: 0)
     private var dynamic = false
     private var currentSize: CGSize?
-    
+
     public init(printing: PrintingPlugin, index: Int) {
         self.printing = printing
         self.index = index
@@ -312,18 +312,19 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
     }
 
     public func rasterPdf(data: Data, pages: [Int]?, scale: CGFloat) {
-        let provider = CGDataProvider(data: data as CFData)!
-        let document = CGPDFDocument(provider)
-        if document == nil {
+        guard
+            let provider = CGDataProvider(data: data as CFData),
+            let document = CGPDFDocument(provider)
+        else {
             printing.onPageRasterEnd(printJob: self, error: "Cannot raster a malformed PDF file")
             return
         }
 
         DispatchQueue.global().async {
-            let pageCount = document!.numberOfPages
+            let pageCount = document.numberOfPages
 
             for pageNum in pages ?? Array(0 ... pageCount - 1) {
-                guard let page = document!.page(at: pageNum + 1) else { continue }
+                guard let page = document.page(at: pageNum + 1) else { continue }
                 let angle = CGFloat(page.rotationAngle) * CGFloat.pi / -180
                 let rect = page.getBoxRect(.mediaBox)
                 let width = Int(abs((cos(angle) * rect.width + sin(angle) * rect.height) * scale))

--- a/printing/macos/Classes/PrintJob.swift
+++ b/printing/macos/Classes/PrintJob.swift
@@ -252,18 +252,19 @@ public class PrintJob: NSView, NSSharingServicePickerDelegate {
     }
 
     public func rasterPdf(data: Data, pages: [Int]?, scale: CGFloat) {
-        let provider = CGDataProvider(data: data as CFData)!
-        let document = CGPDFDocument(provider)
-        if document == nil {
+        guard
+            let provider = CGDataProvider(data: data as CFData),
+            let document = CGPDFDocument(provider)
+        else {
             printing.onPageRasterEnd(printJob: self, error: "Cannot raster a malformed PDF file")
             return
         }
 
         DispatchQueue.global().async {
-            let pageCount = document!.numberOfPages
+            let pageCount = document.numberOfPages
 
             for pageNum in pages ?? Array(0 ... pageCount - 1) {
-                guard let page = document!.page(at: pageNum + 1) else { continue }
+                guard let page = document.page(at: pageNum + 1) else { continue }
                 let angle = CGFloat(page.rotationAngle) * CGFloat.pi / -180
                 let rect = page.getBoxRect(.mediaBox)
                 let width = Int(abs((cos(angle) * rect.width + sin(angle) * rect.height) * scale))


### PR DESCRIPTION
## Description

When instantiating a `CGDataProvider` if the instantiation is unsuccessful (returns `nil`), we were force-unwrapping the`nil` value, causing a crash.

To fix that, the code was updated to use `guard let` to safely unwrap the data and in case of `nil` values, return the correct error message.

## Flutter Example code to crash the application

Because we don't have tests that cover the native platform, I am providing below a working example that reproduces the bug:

```dart
@override
Widget build(BuildContext context) {
  return MaterialApp(
    home: Scaffold(
      appBar: AppBar(title: Text(title)),
      body: PdfPreview(
        build: (format) => Uint8List(0),
      ),
    ),
  );
}
```