### PR TITLE
fix: wrong format in directPrintPdf

### DIFF
--- a/printing/ios/Classes/PrintJob.swift
+++ b/printing/ios/Classes/PrintJob.swift
@@ -134,13 +134,15 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
 
         printing.onCompleted(printJob: self, completed: completed, error: error?.localizedDescription as NSString?)
     }
-
-    public func printInteractionController(_ printInteractionController: UIPrintInteractionController, cutLengthFor paper: UIPrintPaper) -> CGFloat {
-        if currentSize == nil{
-            return  paper.paperSize.height
+    
+    public func printInteractionController(_ printController: UIPrintInteractionController, choosePaper paperList: [UIPrintPaper]) -> UIPrintPaper {
+        if currentSize == nil {
+            return paperList[0]
         }
-
-        return currentSize!.height
+        
+        let bestPaper = UIPrintPaper.bestPaper(forPageSize: currentSize!, withPapersFrom: paperList)
+        
+        return bestPaper
     }
 
     func printPdf(name: String, withPageSize size: CGSize, andMargin margin: CGRect, withPrinter printerID: String?, dynamically dyn: Bool) {


### PR DESCRIPTION
Hi,

Currently we have 2 options to print in IOS.

1. Using `layoutPdf` function that triggers print options system UI. 
2. Using `pickerPrinter + directPrintPdf` functions. This way we won't show the print options native page, instead we will show the list of printers available then when the user chooses one we will pass it to the directPrintPdf which will print silently.

The drawback of the **1st option** is that the default paper size in print options dialog is always shown as letter, even if we pass another format to it (A4 for example).

I think it is a known issue in native iOS based on this link [iOS Custom UIPrintPaper size
](https://developer.apple.com/forums/thread/30197)
Espicially the last comment which said 
> Surprisingly I followed the first steps the same way. Then I tried to override as you suggested in xcode 13.4. in 2022, still there is no way to avoid it falling back to Letter.

We also have an issue about it #1127

The **2nd option** has the same issue as well in the current implementation. However, I fixed it by changing the `printInteractionController` implementation

### MORE EXPLANATION
The job of `printInteractionController` is that we pass it the paper size that we want, and it will compare it with the `paperList` parameter then it will return our paper size if available, or the nearest one based on width and height.

For some reason the previous implementation of `printInteractionController` won't get called when using 1st or 2nd options.
My implementation will be called in both options, here is what happen when it get called:

1. `layoutPdf`: if there are printers, `printInteractionController` will get called, but the `paperList` parameter will have only 1 format which is letter. Which I think it is a bug in native iOS
2. `directPrintPdf`: if there are printers, `printInteractionController` will get called and the `paperList` parameter will have the available formats supported by the printer. Which is what we want.
