### PR TITLE
Chore: image.fromBytes() pass bytes offset.

### DIFF
--- a/pdf/lib/src/pdf/raster.dart
+++ b/pdf/lib/src/pdf/raster.dart
@@ -129,6 +129,7 @@ class PdfRasterBase {
       width: width,
       height: height,
       bytes: pixels.buffer,
+      bytesOffset: pixels.offsetInBytes,
       format: im.Format.uint8,
       numChannels: 4,
     );


### PR DESCRIPTION
It fixes, rasterization of images have color swaps.