### PR TITLE
Add range check during raster

### DIFF
--- a/printing/lib/src/preview/raster.dart
+++ b/printing/lib/src/preview/raster.dart
@@ -167,19 +167,17 @@ mixin PdfPreviewRaster on State<PdfPreviewCustom> {
           _rastering = false;
           return;
         }
+
+        final pdfPreviewPageData = PdfPreviewPageData(
+          image: MemoryImage(await page.toPng()),
+          width: page.width,
+          height: page.height,
+        );
         if (pages.length <= pageNum) {
-          pages.add(PdfPreviewPageData(
-            image: MemoryImage(await page.toPng()),
-            width: page.width,
-            height: page.height,
-          ));
+          pages.add(pdfPreviewPageData);
         } else {
           pages[pageNum].image.evict();
-          pages[pageNum] = PdfPreviewPageData(
-            image: MemoryImage(await page.toPng()),
-            width: page.width,
-            height: page.height,
-          );
+          pages[pageNum] = pdfPreviewPageData;
         }
 
         if (mounted) {


### PR DESCRIPTION
There are the following non-fatal exceptions in the Firebase crashlytics:

```
Non-fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError
RangeError (start): Invalid value: Not in inclusive range 0..1: 2. Error thrown while rastering a PDF.
```

```
Non-fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError
RangeError (length): Invalid value: Valid value range is empty: 0. Error thrown while rastering a PDF.
```

So added a check before the removeRange.