### PR TITLE
Throw multi pages error explicitly

### DIFF
--- a/pdf/CHANGELOG.md
+++ b/pdf/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.10.6
+
+- Throw multi page error explicitly.
+
 ## 3.10.5
 
 - Improve TTF writer with multi-compound characters

--- a/pdf/lib/src/widgets/multi_page.dart
+++ b/pdf/lib/src/widgets/multi_page.dart
@@ -246,14 +246,11 @@ class MultiPage extends Page {
     while (_index < children.length) {
       final child = children[_index];
 
-      assert(() {
-        // Detect too big widgets
-        if (sameCount++ > maxPages) {
-          throw Exception(
-              'This widget created more than $maxPages pages. This may be an issue in the widget or the document. See https://pub.dev/documentation/pdf/latest/widgets/MultiPage-class.html');
-        }
-        return true;
-      }());
+      // Detect too big widgets
+      if (sameCount++ > maxPages) {
+        throw TooManyPagesException(
+            'This widget created more than $maxPages pages. This may be an issue in the widget or the document. See https://pub.dev/documentation/pdf/latest/widgets/MultiPage-class.html');
+      }
 
       // Create a new page if we don't already have one
       if (context == null || child is NewPage) {
@@ -578,4 +575,11 @@ class MultiPage extends Page {
       }
     }
   }
+}
+
+/// Exception thrown when generator populates more pages than [maxPages].
+class TooManyPagesException implements Exception {
+  TooManyPagesException(this.message);
+
+  final String message;
 }

--- a/pdf/pubspec.yaml
+++ b/pdf/pubspec.yaml
@@ -6,7 +6,7 @@ issue_tracker: https://github.com/DavBfr/dart_pdf/issues
 screenshots:
   - description: 'Example of a generated document'
     path: example.jpg
-version: 3.10.5
+version: 3.10.6
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
Before https://github.com/DavBfr/dart_pdf/issues/1354 is resolved, we'd like to explicitly handle "more than maxPages count error" explicitly.

Currently, in debug we can show an error message to the users (allowing them to change content) and in release mode app just crashes (OOM).