### PR TITLE
make pdf background transparent on windows

### DIFF
--- a/printing/linux/print_job.cc
+++ b/printing/linux/print_job.cc
@@ -288,8 +288,8 @@ void print_job::raster_pdf(const uint8_t data[],
     auto bWidth = static_cast<int>(width * scale);
     auto bHeight = static_cast<int>(height * scale);
 
-    auto bitmap = FPDFBitmap_Create(bWidth, bHeight, 0);
-    FPDFBitmap_FillRect(bitmap, 0, 0, bWidth, bHeight, 0xffffffff);
+    auto bitmap = FPDFBitmap_Create(bWidth, bHeight, 1);
+    FPDFBitmap_FillRect(bitmap, 0, 0, bWidth, bHeight, 0x00ffffff);
 
     FPDF_RenderPageBitmap(bitmap, page, 0, 0, bWidth, bHeight, 0,
                           FPDF_ANNOT | FPDF_LCD_TEXT | FPDF_NO_NATIVETEXT);

--- a/printing/windows/print_job.cpp
+++ b/printing/windows/print_job.cpp
@@ -361,8 +361,8 @@ void PrintJob::rasterPdf(std::vector<uint8_t> data,
     auto bWidth = static_cast<int>(width * scale);
     auto bHeight = static_cast<int>(height * scale);
 
-    auto bitmap = FPDFBitmap_Create(bWidth, bHeight, 0);
-    FPDFBitmap_FillRect(bitmap, 0, 0, bWidth, bHeight, 0xffffffff);
+    auto bitmap = FPDFBitmap_Create(bWidth, bHeight, 1);
+    FPDFBitmap_FillRect(bitmap, 0, 0, bWidth, bHeight, 0x00ffffff);
 
     FPDF_RenderPageBitmap(bitmap, page, 0, 0, bWidth, bHeight, 0,
                           FPDF_ANNOT | FPDF_LCD_TEXT);


### PR DESCRIPTION
on macOS the background of the pdf is transparent so we can use `pdfPreviewPageDecoration` to set the background on the preview only, but on Windows, the background is white so using `pdfPreviewPageDecoration` doesn't work which causes a difference in results between macOS and windows rendering.

This PR sets the background to be transparent so that we get consistent results in macOS and Windows