### PR TITLE
lookup index of glyph for space character

### DIFF
--- a/pdf/lib/src/pdf/font/ttf_writer.dart
+++ b/pdf/lib/src/pdf/font/ttf_writer.dart
@@ -74,7 +74,7 @@ class TtfWriter {
 
     for (final char in chars) {
       if (char == 32) {
-        final glyph = TtfGlyphInfo(32, Uint8List(0), const <int>[]);
+        final glyph = TtfGlyphInfo(ttf.charToGlyphIndexMap[char]!, Uint8List(0), const <int>[]);
         glyphsMap[glyph.index] = glyph;
         charMap[char] = glyph.index;
         continue;


### PR DESCRIPTION
This corrects an issue with text rendering when using ttf files.  The original code assume the glyph index for a space is always 32, though this is not necessarily true, so just changed it to look it up for the given font.