### PR TITLE
fix: Update ViewConfiguration to comply with Flutter `>=3.17.0-19.0.pre`

### DIFF
--- a/printing/lib/src/widget_wrapper.dart
+++ b/printing/lib/src/widget_wrapper.dart
@@ -170,7 +170,7 @@ class WidgetWrapper extends pw.ImageProvider {
       child: RenderPositionedBox(
           alignment: Alignment.center, child: repaintBoundary),
       configuration: ViewConfiguration(
-          constraints: ViewConstraints.tight(
+          constraints: ui.ViewConstraints.tight(
               Size(computedConstraints.maxWidth, computedConstraints.maxHeight)),
           devicePixelRatio: view.devicePixelRatio),
       view: view,

--- a/printing/lib/src/widget_wrapper.dart
+++ b/printing/lib/src/widget_wrapper.dart
@@ -170,8 +170,8 @@ class WidgetWrapper extends pw.ImageProvider {
       child: RenderPositionedBox(
           alignment: Alignment.center, child: repaintBoundary),
       configuration: ViewConfiguration(
-          size:
-              Size(computedConstraints.maxWidth, computedConstraints.maxHeight),
+          constraints: ViewConstraints.tight(
+              Size(computedConstraints.maxWidth, computedConstraints.maxHeight)),
           devicePixelRatio: view.devicePixelRatio),
       view: view,
     );

--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -19,7 +19,7 @@ version: 5.11.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  flutter: ">=3.17.0-19.0.pre"
 
 dependencies:
   ffi: ">=1.1.0 <3.0.0"


### PR DESCRIPTION
The `size` parameter of ViewConfiguration does not exist any more in the latest Flutter master.

This is only a Draft PR to keep track of that issue. This doesn't necessarily be merged soon, as it needs bumping min Flutter version, when it will be released like that.

See: https://github.com/flutter/flutter/pull/138648/files#r1413066068
See: https://github.com/flutter/flutter/pull/138648