### PR TITLE
add support for hyphenation

### DIFF
--- a/pdf/lib/src/widgets/text.dart
+++ b/pdf/lib/src/widgets/text.dart
@@ -957,16 +957,15 @@ class RichText extends Widget with SpanningWidget {
                   if (syllables.length > 1) {
                     String fits = '';
                     for (String syllable in syllables) {
-                      double calcWidth = ((font.stringMetrics(
+                      if (offsetX + ((font.stringMetrics(
                           fits + syllable + '-',
                           letterSpacing: style.letterSpacing! /
                               (style.fontSize! * textScaleFactor)) *
-                          (style.fontSize! * textScaleFactor)).width);
-                      if (offsetX + calcWidth <= constraintWidth + 0.00001) {
-                        fits += syllable;
-                        continue;
+                          (style.fontSize! * textScaleFactor)).width) >
+                          constraintWidth + 0.00001) {
+                        break;
                       }
-                      break;
+                      fits += syllable;
                     }
                     if (fits.isNotEmpty) {
                       words[index] = fits + '-';

--- a/pdf/lib/src/widgets/text.dart
+++ b/pdf/lib/src/widgets/text.dart
@@ -658,6 +658,8 @@ class RichTextContext extends WidgetContext {
       '$runtimeType Offset: $startOffset -> $endOffset  Span: $spanStart -> $spanEnd';
 }
 
+typedef List<String> Hyphenation(String word);
+
 class RichText extends Widget with SpanningWidget {
   RichText({
     required this.text,
@@ -668,6 +670,7 @@ class RichText extends Widget with SpanningWidget {
     this.textScaleFactor = 1.0,
     this.maxLines,
     this.overflow = TextOverflow.visible,
+    this.hyphenation,
   });
 
   static bool debug = false;
@@ -699,6 +702,8 @@ class RichText extends Widget with SpanningWidget {
   var _mustClip = false;
 
   List<InlineSpan>? _preprocessed;
+
+  final Hyphenation? hyphenation;
 
   void _appendDecoration(bool append, _TextDecoration td) {
     if (append && _decorations.isNotEmpty) {
@@ -946,6 +951,32 @@ class RichText extends Widget with SpanningWidget {
 
               if (_softWrap &&
                   offsetX + metrics.width > constraintWidth + 0.00001) {
+
+                if (hyphenation != null) {
+                  List<String> syllables = hyphenation!(word);
+                  if (syllables.length > 1) {
+                    String fits = '';
+                    for (String syllable in syllables) {
+                      double calcWidth = ((font.stringMetrics(
+                          fits + syllable + '-',
+                          letterSpacing: style.letterSpacing! /
+                              (style.fontSize! * textScaleFactor)) *
+                          (style.fontSize! * textScaleFactor)).width);
+                      if (offsetX + calcWidth <= constraintWidth + 0.00001) {
+                        fits += syllable;
+                        continue;
+                      }
+                      break;
+                    }
+                    if (fits.isNotEmpty) {
+                      words[index] = fits + '-';
+                      words.insert(index + 1, word.substring(fits.length));
+                      index--;
+                      continue;
+                    }
+                  }
+                }
+
                 if (spanCount > 0 && metrics.width <= constraintWidth) {
                   overflow = true;
                   lines.add(_Line(


### PR DESCRIPTION
Adds a callback for split words into syllables.
Whenever a word overflows a line in text rendering the mechanisms triggers an tries to render the first syllables of a word  with an hyphen in the current line as long as it fits.