### PR TITLE
Update cursors in zoom mode for web

### DIFF
--- a/printing/lib/printing.dart
+++ b/printing/lib/printing.dart
@@ -22,6 +22,7 @@ export 'src/asset_utils.dart';
 export 'src/cache.dart';
 export 'src/callback.dart';
 export 'src/fonts/gfonts.dart';
+export 'src/preview/action_bar_theme.dart';
 export 'src/preview/actions.dart';
 export 'src/preview/pdf_preview.dart';
 export 'src/printer.dart';

--- a/printing/lib/src/preview/action_bar_theme.dart
+++ b/printing/lib/src/preview/action_bar_theme.dart
@@ -10,6 +10,7 @@ class PdfActionBarTheme with Diagnosticable {
     this.textStyle,
     this.elevation = 4,
     this.alignment = WrapAlignment.spaceAround,
+    this.crossAxisAlignment = WrapCrossAlignment.center,
   });
 
   final Color? backgroundColor;
@@ -18,6 +19,7 @@ class PdfActionBarTheme with Diagnosticable {
   final TextStyle? textStyle;
   final double elevation;
   final WrapAlignment alignment;
+  final WrapCrossAlignment crossAxisAlignment;
 
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
@@ -28,6 +30,7 @@ class PdfActionBarTheme with Diagnosticable {
     TextStyle? textStyle,
     double? elevation,
     WrapAlignment? alignment,
+    WrapCrossAlignment? crossAxisAlignment,
   }) {
     return PdfActionBarTheme(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -36,12 +39,20 @@ class PdfActionBarTheme with Diagnosticable {
       textStyle: textStyle ?? this.textStyle,
       elevation: elevation ?? this.elevation,
       alignment: alignment ?? this.alignment,
+      crossAxisAlignment: crossAxisAlignment ?? this.crossAxisAlignment,
     );
   }
 
   @override
-  int get hashCode => Object.hashAll(
-      [backgroundColor, iconColor, height, textStyle, elevation, alignment]);
+  int get hashCode => Object.hashAll([
+        backgroundColor,
+        iconColor,
+        height,
+        textStyle,
+        elevation,
+        alignment,
+        crossAxisAlignment
+      ]);
 
   @override
   bool operator ==(Object other) {
@@ -57,7 +68,8 @@ class PdfActionBarTheme with Diagnosticable {
         other.height == height &&
         other.textStyle == textStyle &&
         other.elevation == elevation &&
-        other.alignment == alignment;
+        other.alignment == alignment &&
+        other.crossAxisAlignment == crossAxisAlignment;
   }
 
   @override
@@ -70,5 +82,8 @@ class PdfActionBarTheme with Diagnosticable {
     properties.add(DoubleProperty('elevation', elevation));
     properties.add(DiagnosticsProperty<WrapAlignment>('alignment', alignment,
         defaultValue: WrapAlignment.spaceAround));
+    properties.add(DiagnosticsProperty<WrapCrossAlignment>(
+        'crossAxisAlignment', crossAxisAlignment,
+        defaultValue: WrapCrossAlignment.center));
   }
 }

--- a/printing/lib/src/preview/action_bar_theme.dart
+++ b/printing/lib/src/preview/action_bar_theme.dart
@@ -8,8 +8,10 @@ class PdfActionBarTheme with Diagnosticable {
     this.iconColor,
     this.height,
     this.textStyle,
-    this.elevation = 4,
+    this.elevation = 4.0,
+    this.actionSpacing = 0.0,
     this.alignment = WrapAlignment.spaceAround,
+    this.runAlignment = WrapAlignment.center,
     this.crossAxisAlignment = WrapCrossAlignment.center,
   });
 
@@ -18,7 +20,9 @@ class PdfActionBarTheme with Diagnosticable {
   final double? height;
   final TextStyle? textStyle;
   final double elevation;
+  final double actionSpacing;
   final WrapAlignment alignment;
+  final WrapAlignment runAlignment;
   final WrapCrossAlignment crossAxisAlignment;
 
   /// Creates a copy of this object but with the given fields replaced with the
@@ -29,7 +33,9 @@ class PdfActionBarTheme with Diagnosticable {
     double? height,
     TextStyle? textStyle,
     double? elevation,
+    double? actionSpacing,
     WrapAlignment? alignment,
+    WrapAlignment? runAlignment,
     WrapCrossAlignment? crossAxisAlignment,
   }) {
     return PdfActionBarTheme(
@@ -38,7 +44,9 @@ class PdfActionBarTheme with Diagnosticable {
       height: height ?? this.height,
       textStyle: textStyle ?? this.textStyle,
       elevation: elevation ?? this.elevation,
+      actionSpacing: actionSpacing ?? this.actionSpacing,
       alignment: alignment ?? this.alignment,
+      runAlignment: runAlignment ?? this.runAlignment,
       crossAxisAlignment: crossAxisAlignment ?? this.crossAxisAlignment,
     );
   }
@@ -50,8 +58,10 @@ class PdfActionBarTheme with Diagnosticable {
         height,
         textStyle,
         elevation,
+        actionSpacing,
         alignment,
-        crossAxisAlignment
+        runAlignment,
+        crossAxisAlignment,
       ]);
 
   @override
@@ -68,7 +78,9 @@ class PdfActionBarTheme with Diagnosticable {
         other.height == height &&
         other.textStyle == textStyle &&
         other.elevation == elevation &&
+        other.actionSpacing == actionSpacing &&
         other.alignment == alignment &&
+        other.runAlignment == runAlignment &&
         other.crossAxisAlignment == crossAxisAlignment;
   }
 
@@ -80,8 +92,12 @@ class PdfActionBarTheme with Diagnosticable {
     properties.add(DoubleProperty('height', height));
     properties.add(DiagnosticsProperty<TextStyle>('textStyle', textStyle));
     properties.add(DoubleProperty('elevation', elevation));
+    properties.add(DoubleProperty('actionSpacing', actionSpacing));
     properties.add(DiagnosticsProperty<WrapAlignment>('alignment', alignment,
         defaultValue: WrapAlignment.spaceAround));
+    properties.add(DiagnosticsProperty<WrapAlignment>(
+        'runAlignment', runAlignment,
+        defaultValue: WrapAlignment.center));
     properties.add(DiagnosticsProperty<WrapCrossAlignment>(
         'crossAxisAlignment', crossAxisAlignment,
         defaultValue: WrapCrossAlignment.center));

--- a/printing/lib/src/preview/action_bar_theme.dart
+++ b/printing/lib/src/preview/action_bar_theme.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class PdfActionBarTheme with Diagnosticable {
+  /// Creates a theme for action bar of [PdfPreviewController].
+  const PdfActionBarTheme({
+    this.backgroundColor,
+    this.iconColor,
+    this.height,
+    this.textStyle,
+    this.elevation = 4,
+    this.alignment = WrapAlignment.spaceAround,
+  });
+
+  final Color? backgroundColor;
+  final Color? iconColor;
+  final double? height;
+  final TextStyle? textStyle;
+  final double elevation;
+  final WrapAlignment alignment;
+
+  /// Creates a copy of this object but with the given fields replaced with the
+  /// new values.
+  PdfActionBarTheme copyWith({
+    Color? backgroundColor,
+    Color? iconColor,
+    double? height,
+    TextStyle? textStyle,
+    double? elevation,
+    WrapAlignment? alignment,
+  }) {
+    return PdfActionBarTheme(
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      iconColor: iconColor ?? this.iconColor,
+      height: height ?? this.height,
+      textStyle: textStyle ?? this.textStyle,
+      elevation: elevation ?? this.elevation,
+      alignment: alignment ?? this.alignment,
+    );
+  }
+
+  @override
+  int get hashCode => Object.hashAll(
+      [backgroundColor, iconColor, height, textStyle, elevation, alignment]);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is PdfActionBarTheme &&
+        other.backgroundColor == backgroundColor &&
+        other.iconColor == iconColor &&
+        other.height == height &&
+        other.textStyle == textStyle &&
+        other.elevation == elevation &&
+        other.alignment == alignment;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(ColorProperty('backgroundColor', backgroundColor));
+    properties.add(ColorProperty('iconColor', iconColor));
+    properties.add(DoubleProperty('height', height));
+    properties.add(DiagnosticsProperty<TextStyle>('textStyle', textStyle));
+    properties.add(DoubleProperty('elevation', elevation));
+    properties.add(DiagnosticsProperty<WrapAlignment>('alignment', alignment,
+        defaultValue: WrapAlignment.spaceAround));
+  }
+}

--- a/printing/lib/src/preview/custom.dart
+++ b/printing/lib/src/preview/custom.dart
@@ -110,7 +110,7 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
     with PdfPreviewRaster {
   final listView = GlobalKey();
 
-  late final List<GlobalKey> _pageGlobalKeys;
+  late List<GlobalKey> _pageGlobalKeys;
 
   bool infoLoaded = false;
 

--- a/printing/lib/src/preview/custom.dart
+++ b/printing/lib/src/preview/custom.dart
@@ -174,16 +174,17 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
     super.didChangeDependencies();
   }
 
-  void scrollToPage(
+  Future<void> scrollToPage(
     int index, {
-    Duration duration = Duration.zero,
+    Duration duration = const Duration(milliseconds: 300),
     Curve curve = Curves.ease,
     ScrollPositionAlignmentPolicy alignmentPolicy =
         ScrollPositionAlignmentPolicy.explicit,
   }) {
-    assert(index >= 0);
-    final pageKey = _pageGlobalKeys[index];
-    Scrollable.ensureVisible(pageKey.currentContext!,
+    assert(index >= 0, 'Index of page cannot be negative');
+    final pageContext = _pageGlobalKeys[index].currentContext;
+    assert(pageContext != null, 'Context of GlobalKey cannot be null');
+    return Scrollable.ensureVisible(pageContext!,
         duration: duration, curve: curve, alignmentPolicy: alignmentPolicy);
   }
 

--- a/printing/lib/src/preview/custom.dart
+++ b/printing/lib/src/preview/custom.dart
@@ -110,7 +110,7 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
     with PdfPreviewRaster {
   final listView = GlobalKey();
 
-  late List<GlobalKey> _pageGlobalKeys;
+  List<GlobalKey> _pageGlobalKeys = <GlobalKey>[];
 
   bool infoLoaded = false;
 
@@ -174,6 +174,7 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
     super.didChangeDependencies();
   }
 
+  /// Ensures that page with [index] is become visible.
   Future<void> scrollToPage(
     int index, {
     Duration duration = const Duration(milliseconds: 300),
@@ -187,6 +188,9 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
     return Scrollable.ensureVisible(pageContext!,
         duration: duration, curve: curve, alignmentPolicy: alignmentPolicy);
   }
+
+  /// Returns the global key for page with [index].
+  Key getPageKey(int index) => _pageGlobalKeys[index];
 
   Widget _showError(Object error) {
     if (widget.onError != null) {
@@ -213,10 +217,12 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
           );
     }
 
-    _pageGlobalKeys = List.generate(
-      pages.length,
-      (index) => GlobalKey(debugLabel: 'pdf-page-$index'),
-    );
+    if (_pageGlobalKeys.isEmpty) {
+      _pageGlobalKeys = List.generate(
+        pages.length,
+        (index) => GlobalKey(debugLabel: 'pdf-page-$index'),
+      );
+    }
 
     if (widget.pagesBuilder != null) {
       return widget.pagesBuilder!(context, pages);
@@ -237,7 +243,7 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
           });
         },
         child: PdfPreviewPage(
-          key: _pageGlobalKeys[index],
+          key: getPageKey(index),
           pageData: pages[index],
           pdfPreviewPageDecoration: widget.pdfPreviewPageDecoration,
           pageMargin: widget.previewPageMargin,

--- a/printing/lib/src/preview/custom.dart
+++ b/printing/lib/src/preview/custom.dart
@@ -110,7 +110,7 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
     with PdfPreviewRaster {
   final listView = GlobalKey();
 
-  late List<GlobalKey> _pageGlobalKeys;
+  late final List<GlobalKey> _pageGlobalKeys;
 
   bool infoLoaded = false;
 
@@ -174,15 +174,6 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
     super.didChangeDependencies();
   }
 
-  @override
-  void initState() {
-    super.initState();
-    _pageGlobalKeys = List.generate(
-      pages.length,
-      (index) => GlobalKey(debugLabel: 'pdf-page-$index'),
-    );
-  }
-
   void scrollToPage(
     int index, {
     Duration duration = Duration.zero,
@@ -221,9 +212,15 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
           );
     }
 
+    _pageGlobalKeys = List.generate(
+      pages.length,
+      (index) => GlobalKey(debugLabel: 'pdf-page-$index'),
+    );
+
     if (widget.pagesBuilder != null) {
       return widget.pagesBuilder!(context, pages);
     }
+
     return ListView.builder(
       controller: scrollController,
       shrinkWrap: widget.shrinkWrap,

--- a/printing/lib/src/preview/custom.dart
+++ b/printing/lib/src/preview/custom.dart
@@ -217,12 +217,10 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
           );
     }
 
-    if (_pageGlobalKeys.isEmpty) {
-      _pageGlobalKeys = List.generate(
-        pages.length,
-        (index) => GlobalKey(debugLabel: 'pdf-page-$index'),
-      );
-    }
+    _pageGlobalKeys = List.generate(
+      pages.length,
+      (index) => GlobalKey(debugLabel: 'pdf-page-$index'),
+    );
 
     if (widget.pagesBuilder != null) {
       return widget.pagesBuilder!(context, pages);

--- a/printing/lib/src/preview/custom.dart
+++ b/printing/lib/src/preview/custom.dart
@@ -285,13 +285,20 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
 
   Widget _zoomPreview() {
     final zoomPreview = GestureDetector(
-      onTap: () {
-        if (kIsWeb) {
-          setState(() {
-            _mouseCursor = SystemMouseCursors.grabbing;
-          });
-        }
-      },
+      onTapDown: kIsWeb
+          ? (_) {
+              setState(() {
+                _mouseCursor = SystemMouseCursors.grabbing;
+              });
+            }
+          : null,
+      onTapUp: kIsWeb
+          ? (_) {
+              setState(() {
+                _mouseCursor = SystemMouseCursors.grab;
+              });
+            }
+          : null,
       onDoubleTap: () {
         setState(() {
           preview = null;

--- a/printing/lib/src/preview/custom.dart
+++ b/printing/lib/src/preview/custom.dart
@@ -110,7 +110,7 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
     with PdfPreviewRaster {
   final listView = GlobalKey();
 
-  List<GlobalKey> _pageGlobalKeys = <GlobalKey>[];
+  final _pageGlobalKeys = List.generate(100, (index) => GlobalKey());
 
   bool infoLoaded = false;
 
@@ -216,11 +216,6 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
             child: CircularProgressIndicator(),
           );
     }
-
-    _pageGlobalKeys = List.generate(
-      pages.length,
-      (index) => GlobalKey(debugLabel: 'pdf-page-$index'),
-    );
 
     if (widget.pagesBuilder != null) {
       return widget.pagesBuilder!(context, pages);

--- a/printing/lib/src/preview/custom.dart
+++ b/printing/lib/src/preview/custom.dart
@@ -245,7 +245,7 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
               preview = index;
               transformationController.value.setIdentity();
               if (kIsWeb) {
-                _mouseCursor = SystemMouseCursors.grab;
+                _updateCursor(SystemMouseCursors.grab);
               }
             });
             _zoomChanged();
@@ -285,32 +285,24 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
 
   Widget _zoomPreview() {
     final zoomPreview = GestureDetector(
-      onTapDown: kIsWeb
-          ? (_) {
-              setState(() {
-                _mouseCursor = SystemMouseCursors.grabbing;
-              });
-            }
-          : null,
-      onTapUp: kIsWeb
-          ? (_) {
-              setState(() {
-                _mouseCursor = SystemMouseCursors.grab;
-              });
-            }
-          : null,
       onDoubleTap: () {
         setState(() {
           preview = null;
           if (kIsWeb) {
-            _mouseCursor = MouseCursor.defer;
+            _updateCursor(MouseCursor.defer);
           }
         });
         _zoomChanged();
       },
+      onLongPressCancel:
+          kIsWeb ? () => _updateCursor(SystemMouseCursors.grab) : null,
+      onLongPressDown:
+          kIsWeb ? (_) => _updateCursor(SystemMouseCursors.grabbing) : null,
       child: InteractiveViewer(
         transformationController: transformationController,
         maxScale: 5,
+        onInteractionEnd:
+            kIsWeb ? (_) => _updateCursor(SystemMouseCursors.grab) : null,
         child: Center(
           child: PdfPreviewPage(
             pageData: pages[preview!],
@@ -321,11 +313,22 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
       ),
     );
     return kIsWeb
-        ? MouseRegion(cursor: _mouseCursor, child: zoomPreview)
+        ? MouseRegion(
+            cursor: _mouseCursor,
+            child: zoomPreview,
+          )
         : zoomPreview;
   }
 
   void _zoomChanged() => widget.onZoomChanged?.call(preview != null);
+
+  void _updateCursor(MouseCursor mouseCursor) {
+    if (mouseCursor != _mouseCursor) {
+      setState(() {
+        _mouseCursor = mouseCursor;
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/printing/lib/src/preview/custom.dart
+++ b/printing/lib/src/preview/custom.dart
@@ -110,6 +110,8 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
     with PdfPreviewRaster {
   final listView = GlobalKey();
 
+  late List<GlobalKey> _pageGlobalKeys;
+
   bool infoLoaded = false;
 
   int? preview;
@@ -172,6 +174,28 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
     super.didChangeDependencies();
   }
 
+  @override
+  void initState() {
+    super.initState();
+    _pageGlobalKeys = List.generate(
+      pages.length,
+      (index) => GlobalKey(debugLabel: 'pdf-page-$index'),
+    );
+  }
+
+  void scrollToPage(
+    int index, {
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
+    ScrollPositionAlignmentPolicy alignmentPolicy =
+        ScrollPositionAlignmentPolicy.explicit,
+  }) {
+    assert(index >= 0);
+    final pageKey = _pageGlobalKeys[index];
+    Scrollable.ensureVisible(pageKey.currentContext!,
+        duration: duration, curve: curve, alignmentPolicy: alignmentPolicy);
+  }
+
   Widget _showError(Object error) {
     if (widget.onError != null) {
       return widget.onError!(context, error);
@@ -215,6 +239,7 @@ class PdfPreviewCustomState extends State<PdfPreviewCustom>
           });
         },
         child: PdfPreviewPage(
+          key: _pageGlobalKeys[index],
           pageData: pages[index],
           pdfPreviewPageDecoration: widget.pdfPreviewPageDecoration,
           pageMargin: widget.previewPageMargin,

--- a/printing/lib/src/preview/pdf_preview.dart
+++ b/printing/lib/src/preview/pdf_preview.dart
@@ -65,6 +65,7 @@ class PdfPreview extends StatefulWidget {
     this.dpi,
     this.actionBarTheme = const PdfActionBarTheme(),
     this.enableScrollToPage = false,
+    this.onZoomChanged,
   })  : _pagesBuilder = null,
         super(key: key);
 
@@ -125,6 +126,7 @@ class PdfPreview extends StatefulWidget {
     this.actionBarTheme = const PdfActionBarTheme(),
     required CustomPdfPagesBuilder pagesBuilder,
     this.enableScrollToPage = false,
+    this.onZoomChanged,
   })  : _pagesBuilder = pagesBuilder,
         super(key: key);
 
@@ -237,6 +239,9 @@ class PdfPreview extends StatefulWidget {
 
   /// Whether scroll to page functionality enabled.
   final bool enableScrollToPage;
+
+  /// The zoom mode has changed
+  final ValueChanged<bool>? onZoomChanged;
 
   @override
   PdfPreviewState createState() => PdfPreviewState();
@@ -411,6 +416,7 @@ class PdfPreviewState extends State<PdfPreview> {
                 pagesBuilder: widget._pagesBuilder,
                 dpi: widget.dpi,
                 enableScrollToPage: widget.enableScrollToPage,
+                onZoomChanged: widget.onZoomChanged,
               );
             }),
           ),

--- a/printing/lib/src/preview/pdf_preview.dart
+++ b/printing/lib/src/preview/pdf_preview.dart
@@ -64,6 +64,7 @@ class PdfPreview extends StatefulWidget {
     this.onPageFormatChanged,
     this.dpi,
     this.actionBarTheme = const PdfActionBarTheme(),
+    this.enableScrollToPage = false,
   })  : _pagesBuilder = null,
         super(key: key);
 
@@ -123,6 +124,7 @@ class PdfPreview extends StatefulWidget {
     this.dpi,
     this.actionBarTheme = const PdfActionBarTheme(),
     required CustomPdfPagesBuilder pagesBuilder,
+    this.enableScrollToPage = false,
   })  : _pagesBuilder = pagesBuilder,
         super(key: key);
 
@@ -233,6 +235,9 @@ class PdfPreview extends StatefulWidget {
   /// their own pages.
   final CustomPdfPagesBuilder? _pagesBuilder;
 
+  /// Whether scroll to page functionality enabled.
+  final bool enableScrollToPage;
+
   @override
   PdfPreviewState createState() => PdfPreviewState();
 }
@@ -302,7 +307,6 @@ class PdfPreviewState extends State<PdfPreview> {
         initialPageFormat: previewData.pageFormat,
         onComputeActualPageFormat: computeActualPageFormat,
       );
-      setState(() {});
     }
     super.didUpdateWidget(oldWidget);
   }
@@ -406,6 +410,7 @@ class PdfPreviewState extends State<PdfPreview> {
                 shouldRepaint: widget.shouldRepaint,
                 pagesBuilder: widget._pagesBuilder,
                 dpi: widget.dpi,
+                enableScrollToPage: widget.enableScrollToPage,
               );
             }),
           ),

--- a/printing/lib/src/preview/pdf_preview.dart
+++ b/printing/lib/src/preview/pdf_preview.dart
@@ -21,6 +21,7 @@ import 'package:pdf/widgets.dart' as pw;
 import '../callback.dart';
 import '../printing.dart';
 import '../printing_info.dart';
+import 'action_bar_theme.dart';
 import 'actions.dart';
 import 'controller.dart';
 import 'custom.dart';
@@ -62,6 +63,7 @@ class PdfPreview extends StatefulWidget {
     this.loadingWidget,
     this.onPageFormatChanged,
     this.dpi,
+    this.actionBarTheme = const PdfActionBarTheme(),
   })  : _pagesBuilder = null,
         super(key: key);
 
@@ -119,6 +121,7 @@ class PdfPreview extends StatefulWidget {
     this.loadingWidget,
     this.onPageFormatChanged,
     this.dpi,
+    this.actionBarTheme = const PdfActionBarTheme(),
     required CustomPdfPagesBuilder pagesBuilder,
   })  : _pagesBuilder = pagesBuilder,
         super(key: key);
@@ -222,6 +225,9 @@ class PdfPreview extends StatefulWidget {
   /// The rendering dots per inch resolution
   /// If not provided, this value is calculated.
   final double? dpi;
+
+  /// The style of actions bar.
+  final PdfActionBarTheme actionBarTheme;
 
   /// clients can pass this builder to render
   /// their own pages.
@@ -406,16 +412,19 @@ class PdfPreviewState extends State<PdfPreview> {
           if (actions.isNotEmpty)
             IconTheme.merge(
               data: IconThemeData(
-                color: iconColor,
+                color: widget.actionBarTheme.iconColor ?? iconColor,
               ),
               child: Material(
-                elevation: 4,
-                color: theme.primaryColor,
+                elevation: widget.actionBarTheme.elevation,
+                color:
+                    widget.actionBarTheme.backgroundColor ?? theme.primaryColor,
+                textStyle: widget.actionBarTheme.textStyle,
                 child: SizedBox(
                   width: double.infinity,
+                  height: widget.actionBarTheme.height,
                   child: SafeArea(
                     child: Wrap(
-                      alignment: WrapAlignment.spaceAround,
+                      alignment: widget.actionBarTheme.alignment,
                       children: actions,
                     ),
                   ),

--- a/printing/lib/src/preview/pdf_preview.dart
+++ b/printing/lib/src/preview/pdf_preview.dart
@@ -424,7 +424,9 @@ class PdfPreviewState extends State<PdfPreview> {
                   height: widget.actionBarTheme.height,
                   child: SafeArea(
                     child: Wrap(
+                      spacing: widget.actionBarTheme.actionSpacing,
                       alignment: widget.actionBarTheme.alignment,
+                      runAlignment: widget.actionBarTheme.runAlignment,
                       crossAxisAlignment:
                           widget.actionBarTheme.crossAxisAlignment,
                       children: actions,

--- a/printing/lib/src/preview/pdf_preview.dart
+++ b/printing/lib/src/preview/pdf_preview.dart
@@ -425,6 +425,8 @@ class PdfPreviewState extends State<PdfPreview> {
                   child: SafeArea(
                     child: Wrap(
                       alignment: widget.actionBarTheme.alignment,
+                      crossAxisAlignment:
+                          widget.actionBarTheme.crossAxisAlignment,
                       children: actions,
                     ),
                   ),


### PR DESCRIPTION
Change cursor to `grab` when zoom mode enabled. Change cursor to `grabging` when PDF is zooming. Add method `onZoomChanged`  to notify parent of `PdfPreview`.

This PR is based on PR #1569,