### PR TITLE
Printing raster fix for iOS

### DIFF
--- a/printing/ios/Classes/PrintJob.swift
+++ b/printing/ios/Classes/PrintJob.swift
@@ -350,8 +350,11 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
                 guard let page = document.page(at: pageNum + 1) else { continue }
                 let angle = CGFloat(page.rotationAngle) * CGFloat.pi / -180
                 let rect = page.getBoxRect(.mediaBox)
-                let width = Int(abs((cos(angle) * rect.width + sin(angle) * rect.height) * scale))
-                let height = Int(abs((cos(angle) * rect.height + sin(angle) * rect.width) * scale))
+                let rectCrop = page.getBoxRect(.cropBox)
+                let diffHeight = rectCrop.height - rect.height
+                let diffWidth = rectCrop.width - rect.width
+                let width = Int(abs((cos(angle) * rectCrop.width + sin(angle) * rectCrop.height) * scale))
+                let height = Int(abs((cos(angle) * rectCrop.height + sin(angle) * rectCrop.width) * scale))
                 let stride = width * 4
                 var data = Data(repeating: 0, count: stride * height)
 
@@ -371,7 +374,8 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
                         context!.translateBy(x: CGFloat(width) / 2, y: CGFloat(height) / 2)
                         context!.scaleBy(x: scale, y: scale)
                         context!.rotate(by: angle)
-                        context!.translateBy(x: -rect.width / 2, y: -rect.height / 2)
+                        context!.translateBy(x: -rectCrop.width / 2, y: -rectCrop.height / 2)
+                        context!.translateBy(x: diffWidth, y: diffHeight)
                         context!.drawPDFPage(page)
                     }
                 }


### PR DESCRIPTION
These changes are only relevant for iOS

[CGPDFBox](https://developer.apple.com/documentation/coregraphics/cgpdfbox)
Use mediaBox to find the full size of the PDF
Use cropBox to find the size of the visible content
Use the difference in size to translate assuming the content is at the top of the PDF

Potential issues:
This assumes that the content is at the top of the PDF

Here is an example PDF that has issues currently on iOS
[example.pdf](https://github.com/DavBfr/dart_pdf/files/14044314/example.pdf)

Before:
<img src="https://github.com/DavBfr/dart_pdf/assets/68708352/283a6b8b-19b0-4e23-9b60-7fdedf328c5e" width="400px"/>

After:
<img src="https://github.com/DavBfr/dart_pdf/assets/68708352/05ed7d33-0e57-476f-ae99-6ed20b6e4200" width="400px"/>
