### PR TITLE
Fixed wrong empty line height

### DIFF
--- a/pdf/lib/src/pdf/obj/font.dart
+++ b/pdf/lib/src/pdf/obj/font.dart
@@ -283,7 +283,7 @@ See https://github.com/DavBfr/dart_pdf/wiki/Fonts-Management
   double get descent;
 
   /// Height of an empty line
-  double get lineGap => ascent + descent;
+  double get emptyLineHeight => ascent + (-descent);
 
   /// Internal units per
   int get unitsPerEm;

--- a/pdf/lib/src/widgets/text.dart
+++ b/pdf/lib/src/widgets/text.dart
@@ -1073,7 +1073,8 @@ class RichText extends Widget with SpanningWidget {
               if (spanCount > 0) {
                 offsetY += bottom - top;
               } else {
-                offsetY += font.lineGap * style.fontSize! * textScaleFactor;
+                offsetY +=
+                    font.emptyLineHeight * style.fontSize! * textScaleFactor;
               }
               top = 0;
               bottom = 0;


### PR DESCRIPTION
Negating negative descent to calculate the height of an empty line correctly.

Also renamed lineGap to emptyLineHeight to avoid confusion with semantically different lineGap as known from TrueType etc.