### PR TITLE
fix: correct use of Flutter 3.19's ViewConfiguration constructor

### DIFF
--- a/widget_wrapper/lib/src/widget_wrapper.dart
+++ b/widget_wrapper/lib/src/widget_wrapper.dart
@@ -170,13 +170,9 @@ class WidgetWrapper extends pw.ImageProvider {
       child: RenderPositionedBox(
           alignment: Alignment.center, child: repaintBoundary),
       configuration: ViewConfiguration(
-          physicalConstraints: BoxConstraints(
-            maxWidth: computedConstraints.maxWidth,
-            maxHeight: computedConstraints.maxHeight,
-          ),
-          logicalConstraints: BoxConstraints(
-            maxWidth: computedConstraints.maxWidth,
-            maxHeight: computedConstraints.maxHeight,
+          size: Size(
+            computedConstraints.maxWidth,
+            computedConstraints.maxHeight,
           ),
           devicePixelRatio: view.devicePixelRatio),
       view: view,


### PR DESCRIPTION
Fixes #1603 