### PR TITLE
Allow to use alternative source for PDF.js loading

### DIFF
--- a/printing/README.md
+++ b/printing/README.md
@@ -43,7 +43,7 @@ for documentation.
    <true/>
    ```
 
-5. If you want to manually set the PdfJs library version for the web, a small script
+5. If you want to manually set the Pdf.js library version for the web, a small script
    has to be added to your `web/index.html` file, just before `</head>`.
    Otherwise it is loaded automatically:
 
@@ -51,6 +51,20 @@ for documentation.
    <script>
      var dartPdfJsVersion = "3.2.146";
    </script>
+   ```
+    5.1. If you want to manually set the alternative location for loading Pdf.js library for the web, the following script has to be added to your `web/index.html` file, just before `</head>`.
+
+    ```html
+    <script>
+      var dartPdfJsBaseUrl = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.2.146/";
+    </script>
+   ```
+    It is possible to use local directory which will be resolved to the host where the web app is running.
+
+    ```html
+    <script>
+      var dartPdfJsBaseUrl = "assets/js/pdf/3.2.146/";
+    </script>
    ```
 
 6. For Windows and Linux, you can force the pdfium version and architecture

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -92,7 +92,7 @@ class PrintingPlugin extends PrintingPlatform {
         _pdfJsUrlBase = js.context[_dartPdfJsBaseUrl] as String;
         // Check if only local path is defined
         if (!_pdfJsUrlBase.startsWith(RegExp(r'https?:'))) {
-          final doc = js.context['document'] as html.HtmlDocument;
+          final html.HtmlDocument doc = js.context['document'];
           final location = doc.window!.location as html.Location;
           _pdfJsUrlBase = '${location.origin}/$_pdfJsUrlBase';
         }

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -94,7 +94,7 @@ class PrintingPlugin extends PrintingPlatform {
         if (!_pdfJsUrlBase.startsWith(RegExp(r'https?:'))) {
           final html.HtmlDocument doc = js.context['document'];
           final location = doc.window!.location as html.Location;
-          _pdfJsUrlBase = '${location.origin}/$_pdfJsUrlBase';
+          _pdfJsUrlBase = '${location.host}/$_pdfJsUrlBase';
         }
       } else {
         final pdfJsVersion = js.context.hasProperty(_dartPdfJsVersion)

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -33,6 +33,9 @@ import 'src/printer.dart';
 import 'src/printing_info.dart';
 import 'src/raster.dart';
 
+const _dartPdfJsVersion = 'dartPdfJsVersion';
+const _dartPdfJsBaseUrl = 'dartPdfJsBaseUrl';
+
 /// Print plugin targeting Flutter on the Web
 class PrintingPlugin extends PrintingPlatform {
   /// Registers this class as the default instance of [PrintingPlugin].
@@ -51,14 +54,11 @@ class PrintingPlugin extends PrintingPlatform {
   final _loading = Mutex();
 
   bool get _hasPdfJsLib => js.context.callMethod('eval', <String>[
-        'typeof pdfjsLib !== "undefined" && pdfjsLib.GlobalWorkerOptions.workerSrc!="";'
+        'typeof pdfjsLib !== "undefined" && pdfjsLib.GlobalWorkerOptions.workerSrc != "";'
       ]);
 
-  String get _selectPdfJsVersion => js.context.hasProperty('dartPdfJsVersion')
-      ? js.context['dartPdfJsVersion']
-      : _pdfJsVersion;
-
-  String get _pdfJsUrlBase => '$_pdfJsCdnPath@$_selectPdfJsVersion/';
+  /// The base URL for loading pdf.js library
+  late String _pdfJsUrlBase;
 
   Future<void> _initPlugin() async {
     await _loading.acquire();
@@ -86,10 +86,26 @@ class PrintingPlugin extends PrintingPlatform {
       }
       js.context['module'] = 0;
 
+      // Check if the source of PDF.js library is overriden via
+      // [dartPdfJsBaseUrl] JavaScript  variable.
+      if (js.context.hasProperty(_dartPdfJsBaseUrl)) {
+        _pdfJsUrlBase = js.context[_dartPdfJsBaseUrl] as String;
+        // Check if only local path is defined
+        if (!_pdfJsUrlBase.startsWith(RegExp(r'https?:'))) {
+          final window = js.context as html.Window;
+          _pdfJsUrlBase = '${window.location.origin}/$_pdfJsUrlBase';
+        }
+      } else {
+        final pdfJsVersion = js.context.hasProperty(_dartPdfJsVersion)
+            ? js.context[_dartPdfJsVersion]
+            : _pdfJsVersion;
+        _pdfJsUrlBase = '$_pdfJsCdnPath@$pdfJsVersion/build/';
+      }
+
       final script = html.ScriptElement()
         ..type = 'text/javascript'
         ..async = true
-        ..src = '$_pdfJsUrlBase/build/pdf.min.js';
+        ..src = '${_pdfJsUrlBase}pdf.min.js';
       assert(html.document.head != null);
       html.document.head!.append(script);
       await script.onLoad.first;
@@ -100,7 +116,7 @@ class PrintingPlugin extends PrintingPlatform {
       }
 
       js.context['pdfjsLib']['GlobalWorkerOptions']['workerSrc'] =
-          '$_pdfJsUrlBase/build/pdf.worker.min.js';
+          '${_pdfJsUrlBase}pdf.worker.min.js';
 
       // Restore module and exports
       if (module != null) {

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -92,8 +92,9 @@ class PrintingPlugin extends PrintingPlatform {
         _pdfJsUrlBase = js.context[_dartPdfJsBaseUrl] as String;
         // Check if only local path is defined
         if (!_pdfJsUrlBase.startsWith(RegExp(r'https?:'))) {
-          final window = js.context as html.Window;
-          _pdfJsUrlBase = '${window.location.origin}/$_pdfJsUrlBase';
+          final doc = js.context['document'] as html.HtmlDocument;
+          final location = doc.window!.location as html.Location;
+          _pdfJsUrlBase = '${location.origin}/$_pdfJsUrlBase';
         }
       } else {
         final pdfJsVersion = js.context.hasProperty(_dartPdfJsVersion)

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -90,12 +90,6 @@ class PrintingPlugin extends PrintingPlatform {
       // [dartPdfJsBaseUrl] JavaScript  variable.
       if (js.context.hasProperty(_dartPdfJsBaseUrl)) {
         _pdfJsUrlBase = js.context[_dartPdfJsBaseUrl] as String;
-        // Check if only local path is defined
-        if (!_pdfJsUrlBase.startsWith(RegExp(r'https?:'))) {
-          final html.HtmlDocument doc = js.context['document'];
-          final location = doc.window!.location as html.Location;
-          _pdfJsUrlBase = '${location.host}/$_pdfJsUrlBase';
-        }
       } else {
         final pdfJsVersion = js.context.hasProperty(_dartPdfJsVersion)
             ? js.context[_dartPdfJsVersion]


### PR DESCRIPTION
In noticed that the predefined CDN for PDF printing (https://unpkg.com/pdfjs-dist) is often returns the 502 error. So that inspire me to add functionality when user can change the CDN or even use local copy of pdf.js.

To change the CDN base URL user have to created a JavaScript variable and initialize it with the directory which contains files `pdf.min.js` and `pdf.worker.min.js`.

```html
<script>
  var dartPdfJsBaseUrl = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.2.146/";
</script>
```

To use local storage for PDF scripts, save the required files into the new directory insside the root directory of site and initialize the variable.

```html
<script>
  var dartPdfJsBaseUrl = "assets/js/pdf/";
</script>
```
