### PR TITLE
Update widget_wrapper.dart

### DIFF
--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -31,7 +31,11 @@ dependencies:
   image: ^4.0.02
   js: ">=0.6.3 <1.0.0"
   meta: ">=1.3.0 <2.0.0"
-  pdf: ^3.10.0
+  pdf:
+    git:
+      url: https://github.com/Akinsola1/dart_pdf_forked
+      ref: master
+      path: ./pdf
   pdf_widget_wrapper: '>=1.0.0 <2.0.0'
   plugin_platform_interface: ^2.1.0
 

--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -31,12 +31,20 @@ dependencies:
   image: ^4.0.02
   js: ">=0.6.3 <1.0.0"
   meta: ">=1.3.0 <2.0.0"
+  # old pdf pacakge was here and replaced with mine
   pdf:
     git:
       url: https://github.com/Akinsola1/dart_pdf_forked
       ref: master
       path: ./pdf
-  pdf_widget_wrapper: '>=1.0.0 <2.0.0'
+      
+  # also replacing this with the one i forked
+  # pdf_widget_wrapper: '>=1.0.0 <2.0.0'
+  widget_wrapper:
+    git:
+      url: https://github.com/Akinsola1/dart_pdf_forked
+      ref: master
+      path: ./widget_wrapper
   plugin_platform_interface: ^2.1.0
 
 dev_dependencies:

--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
       
   # also replacing this with the one i forked
   # pdf_widget_wrapper: '>=1.0.0 <2.0.0'
-  widget_wrapper:
+  pdf_widget_wrapper:
     git:
       url: https://github.com/Akinsola1/dart_pdf_forked
       ref: master

--- a/widget_wrapper/lib/src/widget_wrapper.dart
+++ b/widget_wrapper/lib/src/widget_wrapper.dart
@@ -170,10 +170,9 @@ class WidgetWrapper extends pw.ImageProvider {
       child: RenderPositionedBox(
           alignment: Alignment.center, child: repaintBoundary),
       configuration: ViewConfiguration(
-          size: Size(
-            computedConstraints.maxWidth,
-            computedConstraints.maxHeight,
-          ),
+          physicalConstraints: BoxConstraints(maxWidth:computedConstraints.maxWidth, maxHeight: computedConstraints.maxHeight ),
+          // size:
+          //     Size(computedConstraints.maxWidth, computedConstraints.maxHeight),
           devicePixelRatio: view.devicePixelRatio),
       view: view,
     );
@@ -225,6 +224,57 @@ class WidgetWrapper extends pw.ImageProvider {
       width: width ?? this.width!,
       height: height ?? this.height!,
       orientation: orientation,
+    );
+  }
+}
+
+/// ImageProvider that draws a Flutter Widget on a PDF document
+@Deprecated('Use WidgetWrapper instead')
+class WidgetWraper extends WidgetWrapper {
+  WidgetWraper._(
+    Uint8List bytes,
+    int width,
+    int height,
+    PdfImageOrientation orientation,
+    double? dpi,
+  ) : super._(bytes, width, height, orientation, dpi);
+
+  /// Wrap a Flutter Widget identified by a GlobalKey to an ImageProvider.
+  @Deprecated('Use WidgetWrapper.fromKey instead')
+  static Future<WidgetWrapper> fromKey({
+    required GlobalKey key,
+    int? width,
+    int? height,
+    double pixelRatio = 1.0,
+    PdfImageOrientation? orientation,
+    double? dpi,
+  }) {
+    return WidgetWrapper.fromKey(
+      key: key,
+      width: width,
+      pixelRatio: pixelRatio,
+      orientation: orientation,
+      dpi: dpi,
+    );
+  }
+
+  /// Wrap a Flutter Widget to an ImageProvider.
+  @Deprecated('Use WidgetWrapper.fromWidget instead')
+  static Future<WidgetWrapper> fromWidget({
+    required BuildContext context,
+    required Widget widget,
+    required BoxConstraints constraints,
+    double pixelRatio = 1.0,
+    PdfImageOrientation? orientation,
+    double? dpi,
+  }) {
+    return WidgetWrapper.fromWidget(
+      context: context,
+      widget: widget,
+      constraints: constraints,
+      pixelRatio: pixelRatio,
+      orientation: orientation,
+      dpi: dpi,
     );
   }
 }

--- a/widget_wrapper/pubspec.yaml
+++ b/widget_wrapper/pubspec.yaml
@@ -13,7 +13,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  pdf: ^3.10.0
+  # pdf: ^3.10.0
+  pdf:
+    git:
+      url: https://github.com/Akinsola1/dart_pdf_forked
+      ref: master
+      path: ./pdf
 
 dependency_overrides:
   pdf:


### PR DESCRIPTION
On deploying my flutter web application to Vercel, i was welcomed with this error
<img width="1216" alt="Screenshot 2024-03-27 at 1 23 55 AM" src="https://github.com/DavBfr/dart_pdf/assets/68930312/b16bbdd5-0346-4bd7-b9c1-0a18598be106">

In flutter/packages/flutter/lib/src/rendering/view.dart the ViewConfiguration now uses physicalConstraints instead of size. which was causing error on Vercel