### PR TITLE
Fix issues with pdf_widget_wrapper

### DIFF
--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   image: ^4.0.02
   meta: ">=1.3.0 <2.0.0"
   pdf: ^3.10.0
-  pdf_widget_wrapper: '>=1.0.0 <2.0.0'
+  pdf_widget_wrapper:
   plugin_platform_interface: ^2.1.0
   web: ^0.5.1
 
@@ -44,8 +44,8 @@ dev_dependencies:
 dependency_overrides:
   pdf:
     path: ../pdf
-#  pdf_widget_wrapper:
-#    path: ../widget_wrapper
+  pdf_widget_wrapper:
+    path: ../widget_wrapper
 
 flutter:
   plugin:


### PR DESCRIPTION
Previously, the Printing Module utilized an outdated version of pdf_widget_wrapper that encountered issues with certain Dart files. To resolve these issues and ensure compatibility, I have implemented an update that utilizes a locally stored version of the package instead. This update aims to improve stability and integrate the Printing Module seamlessly within the project environment.

- Updated pdf_widget_wrapper to a locally stored version.

- Addressed compatibility issues with affected Dart files.