### PR TITLE
added new printing output type value with print pdf method

### DIFF
--- a/printing/ios/Classes/PrintJob.swift
+++ b/printing/ios/Classes/PrintJob.swift
@@ -149,12 +149,26 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
             return paperList[0]
         }
 
+        for paper in paperList {
+            print("Paper available: \(paper.paperSize.width)x\(paper.paperSize.height)")
+        }
+
+        for paper in paperList {
+            if (paper.paperSize.width == currentSize!.width && paper.paperSize.height == currentSize!.height) ||
+                (paper.paperSize.width == currentSize!.height && paper.paperSize.height == currentSize!.width) {
+                print("Use paper: \(paper.paperSize.width)x\(paper.paperSize.height)")
+                return paper
+            }   
+        }
+
         let bestPaper = UIPrintPaper.bestPaper(forPageSize: currentSize!, withPapersFrom: paperList)
+
+        print("Use best paper: \(bestPaper.paperSize.width)x\(bestPaper.paperSize.height)")
 
         return bestPaper
     }
 
-    func printPdf(name: String, withPageSize size: CGSize, andMargin margin: CGRect, withPrinter printerID: String?, dynamically dyn: Bool) {
+    func printPdf(name: String, withPageSize size: CGSize, andMargin margin: CGRect, withPrinter printerID: String?, dynamically dyn: Bool, outputType type: UIPrintInfo.OutputType) {
         currentSize = size
         dynamic = dyn
         let printing = UIPrintInteractionController.isPrintingAvailable
@@ -175,7 +189,7 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
 
         let printInfo = UIPrintInfo.printInfo()
         printInfo.jobName = jobName!
-        printInfo.outputType = .general
+        printInfo.outputType = type
         if orientation != nil {
             printInfo.orientation = orientation!
             orientation = nil

--- a/printing/ios/Classes/PrintJob.swift
+++ b/printing/ios/Classes/PrintJob.swift
@@ -150,20 +150,13 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
         }
 
         for paper in paperList {
-            print("Paper available: \(paper.paperSize.width)x\(paper.paperSize.height)")
-        }
-
-        for paper in paperList {
             if (paper.paperSize.width == currentSize!.width && paper.paperSize.height == currentSize!.height) ||
                 (paper.paperSize.width == currentSize!.height && paper.paperSize.height == currentSize!.width) {
-                print("Use paper: \(paper.paperSize.width)x\(paper.paperSize.height)")
                 return paper
             }   
         }
 
         let bestPaper = UIPrintPaper.bestPaper(forPageSize: currentSize!, withPapersFrom: paperList)
-
-        print("Use best paper: \(bestPaper.paperSize.width)x\(bestPaper.paperSize.height)")
 
         return bestPaper
     }

--- a/printing/ios/Classes/PrintingPlugin.swift
+++ b/printing/ios/Classes/PrintingPlugin.swift
@@ -60,6 +60,22 @@ public class PrintingPlugin: NSObject, FlutterPlugin {
             let marginBottom = CGFloat((args["marginBottom"] as! NSNumber).floatValue)
             let printJob = PrintJob(printing: self, index: args["job"] as! Int)
             let dynamic = args["dynamic"] as! Bool
+            
+
+            let outputType: UIPrintInfo.OutputType
+            switch (args["outputType"] as! Int) {
+            case 0:
+                outputType = UIPrintInfo.OutputType.general
+            case 1:
+                outputType = UIPrintInfo.OutputType.photo
+            case 2:
+                outputType = UIPrintInfo.OutputType.grayscale
+            case 3:
+                outputType = UIPrintInfo.OutputType.photoGrayscale
+            default:
+                outputType = UIPrintInfo.OutputType.general
+            }
+
             jobs[args["job"] as! UInt32] = printJob
             printJob.printPdf(name: name,
                               withPageSize: CGSize(
@@ -71,8 +87,10 @@ public class PrintingPlugin: NSObject, FlutterPlugin {
                                   y: marginTop,
                                   width: width - marginRight - marginLeft,
                                   height: height - marginBottom - marginTop
-                              ), withPrinter: printer,
-                              dynamically: dynamic)
+                              ),
+                              withPrinter: printer,
+                              dynamically: dynamic,
+                              outputType: outputType)
             result(NSNumber(value: 1))
         } else if call.method == "sharePdf" {
             let object = args["doc"] as! FlutterStandardTypedData

--- a/printing/lib/printing.dart
+++ b/printing/lib/printing.dart
@@ -24,6 +24,7 @@ export 'src/asset_utils.dart';
 export 'src/cache.dart';
 export 'src/callback.dart';
 export 'src/fonts/gfonts.dart';
+export 'src/output_type.dart';
 export 'src/preview/action_bar_theme.dart';
 export 'src/preview/actions.dart';
 export 'src/preview/pdf_preview.dart';

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -29,6 +29,7 @@ import 'package:web/web.dart' as web;
 import 'src/callback.dart';
 import 'src/interface.dart';
 import 'src/mutex.dart';
+import 'src/output_type.dart';
 import 'src/pdfjs.dart';
 import 'src/printer.dart';
 import 'src/printing_info.dart';
@@ -156,6 +157,7 @@ class PrintingPlugin extends PrintingPlatform {
     PdfPageFormat format,
     bool dynamicLayout,
     bool usePrinterSettings,
+    OutputType outputType,
   ) async {
     late Uint8List result;
     try {

--- a/printing/lib/src/interface.dart
+++ b/printing/lib/src/interface.dart
@@ -23,6 +23,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'callback.dart';
 import 'method_channel.dart';
+import 'output_type.dart';
 import 'printer.dart';
 import 'printing_info.dart';
 import 'raster.dart';
@@ -66,6 +67,7 @@ abstract class PrintingPlatform extends PlatformInterface {
     PdfPageFormat format,
     bool dynamicLayout,
     bool usePrinterSettings,
+    OutputType outputType,
   );
 
   /// Enumerate the available printers on the system.

--- a/printing/lib/src/method_channel.dart
+++ b/printing/lib/src/method_channel.dart
@@ -31,6 +31,7 @@ import 'package:pdf/pdf.dart';
 import 'callback.dart';
 import 'interface.dart';
 import 'method_channel_ffi.dart' if (dart.library.js) 'method_channel_js.dart';
+import 'output_type.dart';
 import 'print_job.dart';
 import 'printer.dart';
 import 'printing_info.dart';
@@ -180,6 +181,7 @@ class MethodChannelPrinting extends PrintingPlatform {
     PdfPageFormat format,
     bool dynamicLayout,
     bool usePrinterSettings,
+    OutputType outputType,
   ) async {
     final job = _printJobs.add(
       onCompleted: Completer<bool>(),
@@ -198,6 +200,7 @@ class MethodChannelPrinting extends PrintingPlatform {
       'marginBottom': format.marginBottom,
       'dynamic': dynamicLayout,
       'usePrinterSettings': usePrinterSettings,
+      'outputType': outputType.index,
     };
 
     await _channel.invokeMethod<int>('printPdf', params);

--- a/printing/lib/src/output_type.dart
+++ b/printing/lib/src/output_type.dart
@@ -1,0 +1,6 @@
+enum OutputType {
+  generic,
+  photo,
+  grayscale,
+  photoGrayscale,
+}

--- a/printing/lib/src/printing.dart
+++ b/printing/lib/src/printing.dart
@@ -22,6 +22,7 @@ import 'package:pdf/pdf.dart';
 
 import 'callback.dart';
 import 'interface.dart';
+import 'output_type.dart';
 import 'printer.dart';
 import 'printing_info.dart';
 import 'raster.dart';
@@ -39,12 +40,16 @@ mixin Printing {
   /// Set [usePrinterSettings] to true to use the configuration defined by
   /// the printer. May not work for all the printers and can depend on the
   /// drivers. (Supported platforms: Windows)
+  /// Set [outputType] to [OutputType.generic] to use the default printing
+  /// system, or [OutputType.photos] to use the photo printing system.
+  /// (Supported platforms: iOS)
   static Future<bool> layoutPdf({
     required LayoutCallback onLayout,
     String name = 'Document',
     PdfPageFormat format = PdfPageFormat.standard,
     bool dynamicLayout = true,
     bool usePrinterSettings = false,
+    OutputType outputType = OutputType.generic,
   }) {
     return PrintingPlatform.instance.layoutPdf(
       null,
@@ -53,6 +58,7 @@ mixin Printing {
       format,
       dynamicLayout,
       usePrinterSettings,
+      outputType,
     );
   }
 
@@ -139,6 +145,7 @@ mixin Printing {
     PdfPageFormat format = PdfPageFormat.standard,
     bool dynamicLayout = true,
     bool usePrinterSettings = false,
+    OutputType outputType = OutputType.generic,
   }) {
     return PrintingPlatform.instance.layoutPdf(
       printer,
@@ -147,6 +154,7 @@ mixin Printing {
       format,
       dynamicLayout,
       usePrinterSettings,
+      outputType,
     );
   }
 

--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -15,7 +15,7 @@ topics:
   - print
   - printing
   - report
-version: 5.13.1
+version: 5.13.2
 
 environment:
   sdk: ">=3.3.0 <4.0.0"

--- a/printing/test/printing_test.dart
+++ b/printing/test/printing_test.dart
@@ -108,6 +108,7 @@ class MockPrinting extends Mock
     PdfPageFormat format,
     bool dynamicLayout,
     bool usePrinterSettings,
+    OutputType outputType,
   ) async =>
       true;
 


### PR DESCRIPTION
Currently the printing package doesn't handle the print output type (only iOS side). This value allows to retrieve different paper list from the paper supported by the printer. Previously with .generic sett it couldn't be possible to use for example format like 4x6inches.
Additionally this PR include a new logic to select the paper from the `printInteractionController` method because it happens that the `UIPrintPaper.bestPaper` choose a wrong paper size even if it is available in the supported list.