### PR TITLE
Workaround for UIPrinter not contactable + Force custom paper size

### DIFF
--- a/printing/ios/Classes/CustomPrintPaper.swift
+++ b/printing/ios/Classes/CustomPrintPaper.swift
@@ -1,0 +1,10 @@
+public class CustomPrintPaper: UIPrintPaper {
+    private let size: CGSize
+    
+    public override var paperSize: CGSize { return size }
+    public override var printableRect: CGRect  { return CGRect(origin: CGPoint.zero, size: size) }
+
+    init(size: CGSize) {
+        self.size = size
+    }
+}

--- a/printing/ios/Classes/PrintJob.swift
+++ b/printing/ios/Classes/PrintJob.swift
@@ -25,6 +25,9 @@ func dataProviderReleaseDataCallback(info _: UnsafeMutableRawPointer?, data: Uns
 // Each printer will be identified by its URL string
 var selectedPrinters = [String: UIPrinter]()
 
+// Holds the printer after it was picked
+var pickedPrinter: UIPrinter?
+
 public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate {
     private var printing: PrintingPlugin
     public var index: Int
@@ -36,6 +39,7 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
     private let semaphore = DispatchSemaphore(value: 0)
     private var dynamic = false
     private var currentSize: CGSize?
+    private var forceCustomPrintPaper = false
 
     public init(printing: PrintingPlugin, index: Int) {
         self.printing = printing
@@ -149,12 +153,15 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
             return paperList[0]
         }
 
-        for paper in paperList {
+        if forceCustomPrintPaper {
+            return CustomPrintPaper(size: currentSize!)
+        }
+        
+         for paper in paperList {
             if (paper.paperSize.width == currentSize!.width && paper.paperSize.height == currentSize!.height) ||
-                (paper.paperSize.width == currentSize!.height && paper.paperSize.height == currentSize!.width)
-            {
+                (paper.paperSize.width == currentSize!.height && paper.paperSize.height == currentSize!.width) {
                 return paper
-            }
+            }   
         }
 
         let bestPaper = UIPrintPaper.bestPaper(forPageSize: currentSize!, withPapersFrom: paperList)
@@ -162,9 +169,11 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
         return bestPaper
     }
 
-    func printPdf(name: String, withPageSize size: CGSize, andMargin margin: CGRect, withPrinter printerID: String?, dynamically dyn: Bool, outputType type: UIPrintInfo.OutputType) {
+    func printPdf(name: String, withPageSize size: CGSize, andMargin margin: CGRect, withPrinter printerID: String?, dynamically dyn: Bool, outputType type: UIPrintInfo.OutputType, forceCustomPrintPaper: Bool = false) {
         currentSize = size
         dynamic = dyn
+        self.forceCustomPrintPaper = forceCustomPrintPaper
+
         let printing = UIPrintInteractionController.isPrintingAvailable
         if !printing {
             self.printing.onCompleted(printJob: self, completed: false, error: "Printing not available")
@@ -205,6 +214,14 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
 
             if !selectedPrinters.keys.contains(printerURLString) {
                 selectedPrinters[printerURLString] = UIPrinter(url: printerURL!)
+            }
+
+            // Sometimes using UIPrinter(url:) gives a non-contactable printer.
+            // https://stackoverflow.com/questions/34602302/creating-a-working-uiprinter-object-from-url-for-dialogue-free-printing
+            // This lets use a printer saved during picking and fall back using a printer created with UIPrinter(url:)
+            if (pickedPrinter != nil && selectedPrinters[printerURLString]!.url == pickedPrinter?.url) {
+                controller.print(to: pickedPrinter!, completionHandler: self.completionHandler)
+                return
             }
 
             selectedPrinters[printerURLString]!.contactPrinter { available in
@@ -328,6 +345,9 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
                 "model": printer.makeAndModel as Any,
                 "location": printer.displayLocation as Any,
             ]
+
+            pickedPrinter = printer
+
             result(data)
         }
 

--- a/printing/ios/Classes/PrintingPlugin.swift
+++ b/printing/ios/Classes/PrintingPlugin.swift
@@ -60,6 +60,7 @@ public class PrintingPlugin: NSObject, FlutterPlugin {
             let marginBottom = CGFloat((args["marginBottom"] as! NSNumber).floatValue)
             let printJob = PrintJob(printing: self, index: args["job"] as! Int)
             let dynamic = args["dynamic"] as! Bool
+            let forceCustomPrintPaper = args["forceCustomPrintPaper"] as! Bool
 
             let outputType: UIPrintInfo.OutputType
             switch args["outputType"] as! Int {
@@ -89,7 +90,8 @@ public class PrintingPlugin: NSObject, FlutterPlugin {
                               ),
                               withPrinter: printer,
                               dynamically: dynamic,
-                              outputType: outputType)
+                              outputType: outputType,
+                              forceCustomPrintPaper: forceCustomPrintPaper)
             result(NSNumber(value: 1))
         } else if call.method == "sharePdf" {
             let object = args["doc"] as! FlutterStandardTypedData

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -158,6 +158,7 @@ class PrintingPlugin extends PrintingPlatform {
     bool dynamicLayout,
     bool usePrinterSettings,
     OutputType outputType,
+    bool forceCustomPrintPaper,
   ) async {
     late Uint8List result;
     try {

--- a/printing/lib/src/interface.dart
+++ b/printing/lib/src/interface.dart
@@ -68,6 +68,7 @@ abstract class PrintingPlatform extends PlatformInterface {
     bool dynamicLayout,
     bool usePrinterSettings,
     OutputType outputType,
+    bool forceCustomPrintPaper,
   );
 
   /// Enumerate the available printers on the system.

--- a/printing/lib/src/method_channel.dart
+++ b/printing/lib/src/method_channel.dart
@@ -182,6 +182,7 @@ class MethodChannelPrinting extends PrintingPlatform {
     bool dynamicLayout,
     bool usePrinterSettings,
     OutputType outputType,
+    bool forceCustomPrintPaper,
   ) async {
     final job = _printJobs.add(
       onCompleted: Completer<bool>(),
@@ -201,6 +202,7 @@ class MethodChannelPrinting extends PrintingPlatform {
       'dynamic': dynamicLayout,
       'usePrinterSettings': usePrinterSettings,
       'outputType': outputType.index,
+      'forceCustomPrintPaper': forceCustomPrintPaper,
     };
 
     await _channel.invokeMethod<int>('printPdf', params);

--- a/printing/lib/src/printing.dart
+++ b/printing/lib/src/printing.dart
@@ -40,8 +40,14 @@ mixin Printing {
   /// Set [usePrinterSettings] to true to use the configuration defined by
   /// the printer. May not work for all the printers and can depend on the
   /// drivers. (Supported platforms: Windows)
+  ///
   /// Set [outputType] to [OutputType.generic] to use the default printing
   /// system, or [OutputType.photos] to use the photo printing system.
+  /// (Supported platforms: iOS)
+  ///
+  /// Use [customPrintPaper] to force the printer to use a custom paper size.
+  /// Use value `true` to use [format] as custom paper size, when the printer
+  /// driver will not allows the user to use papers which are actually supported by the printer.
   /// (Supported platforms: iOS)
   static Future<bool> layoutPdf({
     required LayoutCallback onLayout,
@@ -50,6 +56,7 @@ mixin Printing {
     bool dynamicLayout = true,
     bool usePrinterSettings = false,
     OutputType outputType = OutputType.generic,
+    bool forceCustomPrintPaper = false,
   }) {
     return PrintingPlatform.instance.layoutPdf(
       null,
@@ -59,6 +66,7 @@ mixin Printing {
       dynamicLayout,
       usePrinterSettings,
       outputType,
+      forceCustomPrintPaper,
     );
   }
 
@@ -138,6 +146,15 @@ mixin Printing {
   /// Set [usePrinterSettings] to true to use the configuration defined by
   /// the printer. May not work for all the printers and can depend on the
   /// drivers. (Supported platforms: Windows)
+  ///
+  /// Set [outputType] to [OutputType.generic] to use the default printing
+  /// system, or [OutputType.photos] to use the photo printing system.
+  /// (Supported platforms: iOS)
+  ///
+  /// Use [customPrintPaper] to force the printer to use a custom paper size.
+  /// Use value `true` to use [format] as custom paper size, when the printer
+  /// driver will not allows the user to use papers which are actually supported by the printer.
+  /// (Supported platforms: iOS)
   static FutureOr<bool> directPrintPdf({
     required Printer printer,
     required LayoutCallback onLayout,
@@ -146,6 +163,7 @@ mixin Printing {
     bool dynamicLayout = true,
     bool usePrinterSettings = false,
     OutputType outputType = OutputType.generic,
+    bool forceCustomPrintPaper = false,
   }) {
     return PrintingPlatform.instance.layoutPdf(
       printer,
@@ -155,6 +173,7 @@ mixin Printing {
       dynamicLayout,
       usePrinterSettings,
       outputType,
+      forceCustomPrintPaper,
     );
   }
 

--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/DavBfr/dart_pdf/tree/master/printing
 repository: https://github.com/DavBfr/dart_pdf
 issue_tracker: https://github.com/DavBfr/dart_pdf/issues
 screenshots:
-  - description: 'Printing a document on iOS'
+  - description: "Printing a document on iOS"
     path: example.png
 topics:
   - pdf
@@ -15,7 +15,7 @@ topics:
   - print
   - printing
   - report
-version: 5.13.2
+version: 5.13.3
 
 environment:
   sdk: ">=3.3.0 <4.0.0"
@@ -31,7 +31,7 @@ dependencies:
   image: ^4.0.02
   meta: ">=1.3.0 <2.0.0"
   pdf: ^3.10.0
-  pdf_widget_wrapper: '>=1.0.0 <2.0.0'
+  pdf_widget_wrapper: ">=1.0.0 <2.0.0"
   plugin_platform_interface: ^2.1.0
   web: ^0.5.1
 

--- a/printing/test/printing_test.dart
+++ b/printing/test/printing_test.dart
@@ -109,6 +109,7 @@ class MockPrinting extends Mock
     bool dynamicLayout,
     bool usePrinterSettings,
     OutputType outputType,
+    bool forceCustomPrintPaper,
   ) async =>
       true;
 


### PR DESCRIPTION
- implemented fix when UIPrinter isn't contactable (even if it is available) due to an iOS bug.
- added a flag to force using custom paper size to use when the combination of airprint+printer driver choose a wrong paper format.