### PR TITLE
fixes display problems (randomly disappearing text) with textfields

### DIFF
--- a/pdf/lib/src/pdf/obj/catalog.dart
+++ b/pdf/lib/src/pdf/obj/catalog.dart
@@ -141,11 +141,24 @@ class PdfCatalog extends PdfObject<PdfDict> {
       acroForm['/SigFlags'] = PdfNum(pdfDocument.sign?.flagsValue ?? 0) |
           (acroForm['/SigFlags'] as PdfNum? ?? const PdfNum(0));
       final fields = (acroForm['/Fields'] ??= PdfArray()) as PdfArray;
+      final fontRefs = PdfDict();
       for (final w in widgets) {
+        if (w.annot is PdfTextField) {
+          // collect textfield font references
+          PdfTextField tf = w.annot as PdfTextField;
+          fontRefs.addAll(PdfDict.values(
+              {tf.font.name: tf.font.ref()}
+          ));
+        }
         final ref = w.ref();
         if (!fields.values.contains(ref)) {
           fields.add(ref);
         }
+      }
+      if (fontRefs.isNotEmpty) {
+        acroForm['/DR'] = PdfDict.values( // "Document Resources"
+            {'/Font': fontRefs}
+        );
       }
     }
   }


### PR DESCRIPTION
Hello!

I recently had an issue with TextFields in PDFs.
Often, when defocussing a field after changing the text, the text would just disappear (in several PDF-Viewers).

When i compared the PDF to another one (with functioning fields) i detected that the other document referred to a font in the /AcroForm section

After adding the font-refs, the display problems seemed to be fixed.


```
/AcroForm <<
    /SigFlags 0
    /Fields [
      [7 0 R]
    ]
    /DR <<
      /Font <<
        /F5 [5 0 R]
      >>
    >>
  >>
```

