### PR TITLE
Fix JavaScript variable dartPdfJsBaseUrl access from Dart

### DIFF
--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -95,7 +95,7 @@ class PrintingPlugin extends PrintingPlatform {
       // Check if the source of PDF.js library is overridden via
       // [dartPdfJsBaseUrl] JavaScript  variable.
       if (web.window.hasProperty(_dartPdfJsBaseUrl.toJS).toDart) {
-        _pdfJsUrlBase = web.window.getProperty(_dartPdfJsBaseUrl.toJS);
+        _pdfJsUrlBase = web.window.getProperty<js.JSString?>(_dartPdfJsBaseUrl.toJS)!.toDart;
       } else {
         final pdfJsVersion =
             web.window.hasProperty(_dartPdfJsVersion.toJS).toDart


### PR DESCRIPTION
# Title

Fix JavaScript variable `dartPdfJsBaseUrl` access from Dart

# Description

Thank you for maintaining such an excellent library. 

This pull request addresses an issue with how the `dartPdfJsBaseUrl` JavaScript variable is accessed from Dart code. The previous implementation did not correctly handle the conversion from the JavaScript string to Dart, leading to potential exceptions during runtime when retrieving it.

# Changes

Updated the Dart code to correctly convert the `dartPdfJsBaseUrl` variable from JavaScript to Dart’s string type.