### PR TITLE
Add support for custom fonts in SVGs.

### DIFF
--- a/pdf/lib/src/svg/painter.dart
+++ b/pdf/lib/src/svg/painter.dart
@@ -28,7 +28,7 @@ class SvgPainter {
     this._canvas,
     this.document,
     this.boundingBox, {
-    this.customFonts,
+    this.customFontLookup,
   });
 
   final SvgParser parser;
@@ -39,7 +39,7 @@ class SvgPainter {
 
   final PdfRect boundingBox;
 
-  final SvgCustomFonts? customFonts;
+  final SvgCustomFontLookup? customFontLookup;
 
   void paint() {
     final brush = parser.colorFilter == null
@@ -63,7 +63,8 @@ class SvgPainter {
   }
 
   Font getFont(String fontFamily, String fontStyle, String fontWeight) {
-    final customFont = customFonts?.getFont(fontFamily, fontStyle, fontWeight);
+    final customFont =
+        customFontLookup?.call(fontFamily, fontStyle, fontWeight);
     if (customFont != null) {
       return customFont;
     }

--- a/pdf/lib/src/svg/painter.dart
+++ b/pdf/lib/src/svg/painter.dart
@@ -16,6 +16,7 @@
 
 import '../../pdf.dart';
 import '../widgets/font.dart';
+import '../widgets/svg.dart';
 import 'brush.dart';
 import 'color.dart';
 import 'group.dart';
@@ -26,8 +27,9 @@ class SvgPainter {
     this.parser,
     this._canvas,
     this.document,
-    this.boundingBox,
-  );
+    this.boundingBox, {
+    this.customFonts,
+  });
 
   final SvgParser parser;
 
@@ -36,6 +38,8 @@ class SvgPainter {
   final PdfDocument document;
 
   final PdfRect boundingBox;
+
+  final SvgCustomFonts? customFonts;
 
   void paint() {
     final brush = parser.colorFilter == null
@@ -59,6 +63,11 @@ class SvgPainter {
   }
 
   Font getFont(String fontFamily, String fontStyle, String fontWeight) {
+    final customFont = customFonts?.getFont(fontFamily, fontStyle, fontWeight);
+    if (customFont != null) {
+      return customFont;
+    }
+
     switch (fontFamily) {
       case 'serif':
         switch (fontStyle) {

--- a/pdf/lib/src/widgets/svg.dart
+++ b/pdf/lib/src/widgets/svg.dart
@@ -32,7 +32,7 @@ class SvgImage extends Widget {
     double? width,
     double? height,
     PdfColor? colorFilter,
-    SvgCustomFonts? customFonts,
+    SvgCustomFontLookup? customFontLookup,
   }) {
     final xml = XmlDocument.parse(svg);
     final parser = SvgParser(
@@ -47,7 +47,7 @@ class SvgImage extends Widget {
       clip,
       width,
       height,
-      customFonts,
+      customFontLookup,
     );
   }
 
@@ -58,7 +58,7 @@ class SvgImage extends Widget {
     this.clip,
     this.width,
     this.height,
-    this.customFonts,
+    this.customFontLookup,
   );
 
   final SvgParser _svgParser;
@@ -73,7 +73,7 @@ class SvgImage extends Widget {
 
   final double? height;
 
-  final SvgCustomFonts? customFonts;
+  final SvgCustomFontLookup? customFontLookup;
 
   late FittedSizes sizes;
 
@@ -131,7 +131,7 @@ class SvgImage extends Widget {
         context.page.pageFormat.width,
         context.page.pageFormat.height,
       ),
-      customFonts: customFonts,
+      customFontLookup: customFontLookup,
     );
     painter.paint();
     context.canvas.restoreContext();
@@ -161,6 +161,5 @@ class DecorationSvgImage extends DecorationGraphic {
   }
 }
 
-abstract class SvgCustomFonts {
-  Font? getFont(String fontFamily, String fontStyle, String fontWeight);
-}
+typedef SvgCustomFontLookup = Font? Function(
+    String fontFamily, String fontStyle, String fontWeight);

--- a/pdf/lib/src/widgets/svg.dart
+++ b/pdf/lib/src/widgets/svg.dart
@@ -32,6 +32,7 @@ class SvgImage extends Widget {
     double? width,
     double? height,
     PdfColor? colorFilter,
+    SvgCustomFonts? customFonts,
   }) {
     final xml = XmlDocument.parse(svg);
     final parser = SvgParser(
@@ -46,6 +47,7 @@ class SvgImage extends Widget {
       clip,
       width,
       height,
+      customFonts,
     );
   }
 
@@ -56,6 +58,7 @@ class SvgImage extends Widget {
     this.clip,
     this.width,
     this.height,
+    this.customFonts,
   );
 
   final SvgParser _svgParser;
@@ -69,6 +72,8 @@ class SvgImage extends Widget {
   final double? width;
 
   final double? height;
+
+  final SvgCustomFonts? customFonts;
 
   late FittedSizes sizes;
 
@@ -126,6 +131,7 @@ class SvgImage extends Widget {
         context.page.pageFormat.width,
         context.page.pageFormat.height,
       ),
+      customFonts: customFonts,
     );
     painter.paint();
     context.canvas.restoreContext();
@@ -153,4 +159,8 @@ class DecorationSvgImage extends DecorationGraphic {
       constraints: BoxConstraints.tight(box.size),
     );
   }
+}
+
+abstract class SvgCustomFonts {
+  Font? getFont(String fontFamily, String fontStyle, String fontWeight);
 }

--- a/pdf/test/widget_svg_test.dart
+++ b/pdf/test/widget_svg_test.dart
@@ -100,6 +100,18 @@ void main() {
     );
   });
 
+  test('SVG Widgets Text custom fonts', () {
+    pdf.addPage(
+      Page(
+        build: (context) => SvgImage(
+          svg:
+              '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg viewBox="0 0 1000 300" xmlns="http://www.w3.org/2000/svg" version="1.1"><text x="367.055" y="168.954" font-size="55" fill="dodgerblue" font-family="myfont" >Hello, PDF</text><rect x="1" y="1" width="998" height="298" fill="none" stroke="purple" stroke-width="2" /></svg>',
+          customFonts: _CustomFonts(),
+        ),
+      ),
+    );
+  });
+
   test('SVG Widgets Barcode', () {
     pdf.addPage(
       Page(
@@ -199,4 +211,11 @@ void main() {
     final file = File('widgets-svg.pdf');
     await file.writeAsBytes(await pdf.save());
   });
+}
+
+class _CustomFonts implements SvgCustomFonts {
+  @override
+  Font? getFont(String fontFamily, String fontStyle, String fontWeight) {
+    return null;
+  }
 }

--- a/pdf/test/widget_svg_test.dart
+++ b/pdf/test/widget_svg_test.dart
@@ -20,6 +20,8 @@ import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart';
 import 'package:test/test.dart';
 
+import 'utils.dart';
+
 late Document pdf;
 
 void main() {
@@ -101,13 +103,26 @@ void main() {
   });
 
   test('SVG Widgets Text custom fonts', () {
+    const customFamilyName1 = 'Test-Font-Family1';
+    const customFamilyName2 = 'Test-Font-Family2';
+    final customFont1 = loadFont('open-sans-bold.ttf');
+    final customFont2 = loadFont('genyomintw.ttf');
     pdf.addPage(
       Page(
         build: (context) => SvgImage(
-          svg:
-              '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg viewBox="0 0 1000 300" xmlns="http://www.w3.org/2000/svg" version="1.1"><text x="367.055" y="168.954" font-size="55" fill="dodgerblue" font-family="myfont" >Hello, PDF</text><rect x="1" y="1" width="998" height="298" fill="none" stroke="purple" stroke-width="2" /></svg>',
-          customFontLookup: (_, __, ___) => null,
-        ),
+            svg:
+                '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg viewBox="0 0 1000 300" xmlns="http://www.w3.org/2000/svg" version="1.1"><text x="367.055" y="168.954" font-size="55" fill="darkgreen" font-family="$customFamilyName1" >Custom <tspan font-family="$customFamilyName2">fonts</tspan></text><rect x="1" y="1" width="998" height="298" fill="none" stroke="purple" stroke-width="2" /></svg>',
+            customFontLookup:
+                (String fontFamily, String fontStyle, String fontWeight) {
+              switch (fontFamily) {
+                case customFamilyName1:
+                  return customFont1;
+                case customFamilyName2:
+                  return customFont2;
+                default:
+                  return null;
+              }
+            }),
       ),
     );
   });

--- a/pdf/test/widget_svg_test.dart
+++ b/pdf/test/widget_svg_test.dart
@@ -106,7 +106,7 @@ void main() {
         build: (context) => SvgImage(
           svg:
               '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg viewBox="0 0 1000 300" xmlns="http://www.w3.org/2000/svg" version="1.1"><text x="367.055" y="168.954" font-size="55" fill="dodgerblue" font-family="myfont" >Hello, PDF</text><rect x="1" y="1" width="998" height="298" fill="none" stroke="purple" stroke-width="2" /></svg>',
-          customFonts: _CustomFonts(),
+          customFontLookup: (_, __, ___) => null,
         ),
       ),
     );
@@ -211,11 +211,4 @@ void main() {
     final file = File('widgets-svg.pdf');
     await file.writeAsBytes(await pdf.save());
   });
-}
-
-class _CustomFonts implements SvgCustomFonts {
-  @override
-  Font? getFont(String fontFamily, String fontStyle, String fontWeight) {
-    return null;
-  }
 }


### PR DESCRIPTION
This adds the interface `SvgCustomFonts` and a corresponding parameter to the `SvgImage` widget. This provides a mechanism to support SVGs that have known fonts referenced in them.

Closes #1731.

Happy to make any changes!