### PR TITLE
FEAT: Adding helper functions that allow you to override text style and cell content only for specific cells

### DIFF
--- a/pdf/lib/src/widgets/table_helper.dart
+++ b/pdf/lib/src/widgets/table_helper.dart
@@ -24,6 +24,10 @@ import 'text_style.dart';
 import 'theme.dart';
 import 'widget.dart';
 
+typedef OnCell = Widget? Function(int index, dynamic data, int rowNum);
+typedef OnCellTextStyle = TextStyle? Function(
+    int index, dynamic data, int rowNum);
+
 mixin TableHelper {
   static TextAlign _textAlign(Alignment align) {
     if (align.x == 0) {
@@ -71,6 +75,8 @@ mixin TableHelper {
     BoxDecoration? oddRowDecoration,
     TextDirection? headerDirection,
     TextDirection? tableDirection,
+    OnCell? cellBuilder,
+    OnCellTextStyle? textStyleBuilder,
   }) {
     assert(headerCount >= 0);
 
@@ -161,14 +167,17 @@ mixin TableHelper {
                   : cellDecoration(tableRow.length, cell, rowNum),
               child: cell is Widget
                   ? cell
-                  : Text(
-                      cellFormat == null
-                          ? cell.toString()
-                          : cellFormat(tableRow.length, cell),
-                      style: isOdd ? oddCellStyle : cellStyle,
-                      textAlign: _textAlign(align.resolve(textDirection)),
-                      textDirection: tableDirection,
-                    ),
+                  : cellBuilder?.call(tableRow.length, cell, rowNum) ??
+                      Text(
+                        cellFormat == null
+                            ? cell.toString()
+                            : cellFormat(tableRow.length, cell),
+                        style: textStyleBuilder?.call(
+                                tableRow.length, cell, rowNum) ??
+                            (isOdd ? oddCellStyle : cellStyle),
+                        textAlign: _textAlign(align.resolve(textDirection)),
+                        textDirection: tableDirection,
+                      ),
             ),
           );
         }


### PR DESCRIPTION
The TableHelper class is an extremely quick way to generate tables, but there are sometimes small customization that need to added for one or two cells in a table.

These two helper functions allow the user program to set customization points for specific cells but still fall back to the default configurations where they are not needed.

Two Helper functions have been added to TableHelper:
- textStyleBuilder (which you just need to override the TextStyle)
- cellBuilder (when you want to replace the whole cell content