### PR TITLE
Allow generating page content to be asynchronous

### DIFF
--- a/pdf/lib/src/widgets/chart/bar_chart.dart
+++ b/pdf/lib/src/widgets/chart/bar_chart.dart
@@ -17,7 +17,6 @@
 import '../../../pdf.dart';
 import '../flex.dart';
 import '../geometry.dart';
-import '../page.dart';
 import '../widget.dart';
 import 'chart.dart';
 import 'grid_cartesian.dart';
@@ -39,7 +38,7 @@ class BarDataSet<T extends PointChartValue> extends PointDataSet<T> {
     PdfColor? pointColor,
     double pointSize = 3,
     bool drawPoints = false,
-    BuildCallback? shape,
+    LegendBuildCallback? shape,
     Widget Function(Context context, T value)? buildValue,
     ValuePosition valuePosition = ValuePosition.auto,
   })  : drawBorder = drawBorder ?? borderColor != null && color != borderColor,

--- a/pdf/lib/src/widgets/chart/line_chart.dart
+++ b/pdf/lib/src/widgets/chart/line_chart.dart
@@ -16,7 +16,6 @@
 
 import '../../../pdf.dart';
 import '../geometry.dart';
-import '../page.dart';
 import '../widget.dart';
 import 'chart.dart';
 import 'grid_cartesian.dart';
@@ -38,7 +37,7 @@ class LineDataSet<T extends PointChartValue> extends PointDataSet<T> {
     this.drawLine = true,
     this.lineColor,
     bool drawPoints = true,
-    BuildCallback? shape,
+    LegendBuildCallback? shape,
     Widget Function(Context context, T value)? buildValue,
     ValuePosition valuePosition = ValuePosition.auto,
     this.drawSurface = false,

--- a/pdf/lib/src/widgets/chart/point_chart.dart
+++ b/pdf/lib/src/widgets/chart/point_chart.dart
@@ -17,11 +17,12 @@
 import '../../../pdf.dart';
 import '../basic.dart';
 import '../geometry.dart';
-import '../page.dart';
 import '../widget.dart';
 import 'chart.dart';
 
 enum ValuePosition { left, top, right, bottom, auto }
+
+typedef LegendBuildCallback = Widget Function(Context context);
 
 class PointChartValue extends ChartValue {
   const PointChartValue(this.x, this.y);
@@ -56,7 +57,7 @@ class PointDataSet<T extends PointChartValue> extends Dataset {
 
   final double pointSize;
 
-  final BuildCallback? shape;
+  final LegendBuildCallback? shape;
 
   final Widget Function(Context context, T value)? buildValue;
 
@@ -94,7 +95,7 @@ class PointDataSet<T extends PointChartValue> extends Dataset {
   }
 
   @override
-  void paintForeground(Context context) {
+  Future<void> paintForeground(Context context) async {
     super.paintForeground(context);
 
     if (data.isEmpty) {
@@ -120,7 +121,7 @@ class PointDataSet<T extends PointChartValue> extends Dataset {
           Widget.draw(
             SizedBox.square(
               dimension: pointSize * 2,
-              child: shape!(context),
+              child: await shape!(context),
             ),
             offset: p,
             alignment: Alignment.center,

--- a/pdf/lib/src/widgets/multi_page.dart
+++ b/pdf/lib/src/widgets/multi_page.dart
@@ -216,7 +216,8 @@ class MultiPage extends Page {
   }
 
   @override
-  void generate(Document document, {bool insert = true, int? index}) {
+  Future<void> generate(Document document,
+      {bool insert = true, int? index}) async {
     assert(pageFormat.width > 0 && pageFormat.width < double.infinity);
     assert(pageFormat.height > 0 && pageFormat.height < double.infinity);
 
@@ -248,7 +249,7 @@ class MultiPage extends Page {
       if (pageTheme.textDirection != null)
         InheritedDirectionality(pageTheme.textDirection),
     ]);
-    final children = _buildList(baseContext);
+    final children = await _buildList(baseContext);
     WidgetContext? widgetContext;
 
     while (_index < children.length) {
@@ -300,7 +301,7 @@ class MultiPage extends Page {
         ));
 
         if (header != null) {
-          final headerWidget = header!(context);
+          final headerWidget = await header!(context);
 
           headerWidget.layout(context, constraints, parentUsesSize: false);
           assert(headerWidget.box != null);
@@ -308,7 +309,7 @@ class MultiPage extends Page {
         }
 
         if (footer != null) {
-          final footerWidget = footer!(context);
+          final footerWidget = await footer!(context);
 
           footerWidget.layout(context, constraints, parentUsesSize: false);
           assert(footerWidget.box != null);
@@ -395,7 +396,7 @@ class MultiPage extends Page {
   }
 
   @override
-  void postProcess(Document document) {
+  Future<void> postProcess(Document document) async {
     final _margin = resolvedMargin!;
     final _mustRotate = mustRotate;
     final pageHeight = _mustRotate ? pageFormat.width : pageFormat.height;
@@ -412,7 +413,7 @@ class MultiPage extends Page {
           _mustRotate ? pageHeightMargin - _margin.left : _margin.bottom;
 
       if (pageTheme.buildBackground != null) {
-        final child = pageTheme.buildBackground!(page.context);
+        final child = await pageTheme.buildBackground!(page.context);
 
         child.layout(page.context, page.fullConstraints, parentUsesSize: false);
         assert(child.box != null);
@@ -444,7 +445,7 @@ class MultiPage extends Page {
       }
 
       if (header != null) {
-        final headerWidget = header!(page.context);
+        final headerWidget = await header!(page.context);
         headerWidget.layout(page.context, page.constraints,
             parentUsesSize: false);
         assert(headerWidget.box != null);
@@ -457,7 +458,7 @@ class MultiPage extends Page {
       }
 
       if (footer != null) {
-        final footerWidget = footer!(page.context);
+        final footerWidget = await footer!(page.context);
         footerWidget.layout(page.context, page.constraints,
             parentUsesSize: false);
         assert(footerWidget.box != null);
@@ -580,7 +581,7 @@ class MultiPage extends Page {
       }
 
       if (pageTheme.buildForeground != null) {
-        final child = pageTheme.buildForeground!(page.context);
+        final child = await pageTheme.buildForeground!(page.context);
 
         child.layout(page.context, page.fullConstraints, parentUsesSize: false);
         assert(child.box != null);

--- a/pdf/lib/src/widgets/page.dart
+++ b/pdf/lib/src/widgets/page.dart
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:meta/meta.dart';
@@ -28,8 +29,8 @@ import 'text_style.dart';
 import 'theme.dart';
 import 'widget.dart';
 
-typedef BuildCallback = Widget Function(Context context);
-typedef BuildListCallback = List<Widget> Function(Context context);
+typedef BuildCallback = FutureOr<Widget> Function(Context context);
+typedef BuildListCallback = FutureOr<List<Widget>> Function(Context context);
 
 enum PageOrientation { natural, landscape, portrait }
 
@@ -112,7 +113,7 @@ class Page {
     }
   }
 
-  void postProcess(Document document) {
+  Future<void> postProcess(Document document) async {
     final canvas = _pdfPage!.getGraphics();
     canvas.reset();
     final _margin = resolvedMargin;
@@ -139,7 +140,7 @@ class Page {
     Widget? content;
     Widget? foreground;
 
-    content = _build(context);
+    content = await _build(context);
 
     final size = layout(content, context, constraints);
 
@@ -156,12 +157,12 @@ class Page {
     }
 
     if (pageTheme.buildBackground != null) {
-      background = pageTheme.buildBackground!(context);
+      background = await pageTheme.buildBackground!(context);
       layout(background, context, constraints);
     }
 
     if (pageTheme.buildForeground != null) {
-      foreground = pageTheme.buildForeground!(context);
+      foreground = await pageTheme.buildForeground!(context);
       layout(foreground, context, constraints);
     }
 

--- a/pdf/lib/src/widgets/widget.dart
+++ b/pdf/lib/src/widgets/widget.dart
@@ -368,10 +368,13 @@ class InheritedWidget extends SingleChildWidget {
   Widget? _child;
 
   @override
-  void layout(Context context, BoxConstraints constraints,
-      {bool parentUsesSize = false}) {
+  void layout(
+    Context context,
+    BoxConstraints constraints, {
+    bool parentUsesSize = false,
+  }) async {
     _context = inherited != null ? context.inheritFrom(inherited!) : context;
-    _child = build!(_context!);
+    _child = await build!(_context!);
     super.layout(_context!, constraints);
   }
 
@@ -394,14 +397,17 @@ class DelayedWidget extends SingleChildWidget {
   Widget? _child;
 
   @override
-  void layout(Context context, BoxConstraints constraints,
-      {bool parentUsesSize = false}) {
-    _child = build(context);
+  Future<void> layout(
+    Context context,
+    BoxConstraints constraints, {
+    bool parentUsesSize = false,
+  }) async {
+    _child = await build(context);
     super.layout(context, constraints);
   }
 
-  void delayedPaint(Context context) {
-    _child = build(context);
+  Future<void> delayedPaint(Context context) async {
+    _child = await build(context);
     child!.layout(
       context,
       BoxConstraints.tight(box!.size),


### PR DESCRIPTION
I open this to feedback.

### Premise

I've been building some complicated PDFs and it would be great if we could generate the list of widgets per page asynchronously. Things like maps, data from other services etc. The change would allow for example GraphPage to build its own content and handle its errors etc.

Example

```
Future<Uint8List> generate() async {
    logger.i('Generating PDF report with ${pages.length} pages');

    final pdf = Document();

    for (final page in pages) {
      await page.preProcessor();

      try {
        final pdfPage = MultiPage(
          pageTheme: pageTheme,
          maxPages: 8000,
          build: (context) => await page.generate(context), //we can create the content async here
        );

        pdf.addPage(pdfPage);
      } on TooManyPagesException catch (e) {
        logger.e('Too many pages when generating page ${page.pageName} with ${e.message}');
      } catch (e, stackTrace) {
        logger.e('Error generating page ${page.pageName}, stackTrace: $stackTrace');
      }
    }

    return pdf.save();
  }
```

We could get all the data and pass it all in, but this also means we can't have nice component style pages that deal with what they need to do in order to get their content and lay it out.

### What about existing users?

Hoping to minimise any disruption to current users via `FutureOr<>`. You don't have to be async unless you want to be.

### Fallout

The built in charts legend now has a seperate tyedef to save the asynchronous code propagating further than it need to.