### PR TITLE
Upgrade archive, fix wasm import

### DIFF
--- a/pdf/pubspec.yaml
+++ b/pdf/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/DavBfr/dart_pdf/tree/master/pdf
 repository: https://github.com/DavBfr/dart_pdf
 issue_tracker: https://github.com/DavBfr/dart_pdf/issues
 screenshots:
-  - description: "Example of a generated document"
+  - description: 'Example of a generated document'
     path: example.jpg
 topics:
   - pdf
@@ -18,7 +18,7 @@ environment:
   sdk: ">=2.19.0 <4.0.0"
 
 dependencies:
-  archive: ^4.0.0
+  archive: ">=3.4.0 <4.1.0"
   barcode: ">=2.2.3 <3.0.0"
   bidi: ^2.0.10
   crypto: ^3.0.0

--- a/pdf/pubspec.yaml
+++ b/pdf/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/DavBfr/dart_pdf/tree/master/pdf
 repository: https://github.com/DavBfr/dart_pdf
 issue_tracker: https://github.com/DavBfr/dart_pdf/issues
 screenshots:
-  - description: 'Example of a generated document'
+  - description: "Example of a generated document"
     path: example.jpg
 topics:
   - pdf
@@ -18,7 +18,7 @@ environment:
   sdk: ">=2.19.0 <4.0.0"
 
 dependencies:
-  archive: ^3.4.0
+  archive: ^4.0.0
   barcode: ">=2.2.3 <3.0.0"
   bidi: ^2.0.10
   crypto: ^3.0.0

--- a/printing/lib/src/method_channel.dart
+++ b/printing/lib/src/method_channel.dart
@@ -30,7 +30,7 @@ import 'package:pdf/pdf.dart';
 
 import 'callback.dart';
 import 'interface.dart';
-import 'method_channel_ffi.dart' if (dart.library.js) 'method_channel_js.dart';
+import 'method_channel_js.dart' if (dart.library.io) 'method_channel_ffi.dart';
 import 'output_type.dart';
 import 'print_job.dart';
 import 'printer.dart';


### PR DESCRIPTION
Closes #1788.

Also fixed the conditional import for ffi when using wasm since `dart.library.js` isn't `true` when using `flutter build web --wasm`.