### PR TITLE
Fix TextStyle merge decoration

### DIFF
--- a/pdf/lib/src/widgets/text_style.dart
+++ b/pdf/lib/src/widgets/text_style.dart
@@ -355,7 +355,7 @@ class TextStyle {
       lineSpacing: other.lineSpacing,
       height: other.height,
       background: other.background,
-      decoration: decoration?.merge(other.decoration),
+      decoration: decoration==null ? other.decoration : decoration!.merge(other.decoration),
       decorationColor: other.decorationColor,
       decorationStyle: other.decorationStyle,
       decorationThickness: other.decorationThickness,


### PR DESCRIPTION
TestStyle merge fails when decoration is null [Issue 1792](https://github.com/DavBfr/dart_pdf/issues/1792)