### PR TITLE
creates catalog.names earlier for attached files

### DIFF
--- a/pdf/lib/src/pdf/obj/catalog.dart
+++ b/pdf/lib/src/pdf/obj/catalog.dart
@@ -98,8 +98,6 @@ class PdfCatalog extends PdfObject<PdfDict> {
     }
 
     if (attached != null && attached!.isNotEmpty) {
-      //params['/Names'] = attached!.catalogNames();
-      names ??= PdfNames(pdfDocument);
       names!.params.merge(attached!.catalogNames());
       params['/AF'] = attached!.catalogAF();
     }

--- a/pdf/lib/src/pdf/obj/pdfa/pdfa_attached_files.dart
+++ b/pdf/lib/src/pdf/obj/pdfa/pdfa_attached_files.dart
@@ -36,6 +36,7 @@ class PdfaAttachedFiles {
       pdfDocument,
       _files,
     );
+    pdfDocument.pdfNames;
     pdfDocument.catalog.attached = this;
   }
 


### PR DESCRIPTION
When attaching files and there is no catalog.names in catalog.prepare 
the `names ??= PdfNames(pdfDocument);` produces an error  when creating/writing the document (-> Concurrent modification during iteration ...).

Solution is to create the catalog.names earlier.