### PR TITLE
attempt to fix incorrect page number in table of contents when footer pushes section to the next page

### DIFF
--- a/pdf/lib/src/widgets/content.dart
+++ b/pdf/lib/src/widgets/content.dart
@@ -121,14 +121,14 @@ class Header extends StatelessWidget {
       return container;
     }
 
-    return Outline(
+    return DelayedWidget(build: (_) => Outline(
       name: text.hashCode.toString(),
       title: title!,
       child: container,
       level: level,
       color: outlineColor,
       style: outlineStyle,
-    );
+    ));
   }
 }
 

--- a/pdf/test/widget_toc_test.dart
+++ b/pdf/test/widget_toc_test.dart
@@ -17,6 +17,7 @@
 import 'dart:io';
 import 'dart:math';
 
+import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart';
 import 'package:test/test.dart';
 
@@ -76,6 +77,35 @@ void main() {
         ],
       ),
       index: 1,
+    );
+  });
+
+  test('page number with footer', () {
+    pdf.addPage(
+      Page(
+        build: (final context) {
+          return Column(
+            children: [TableOfContent()],
+          );
+        },
+      ),
+    );
+    pdf.addPage(
+      MultiPage(
+        footer: (final Context context) {
+          return Container(
+            margin: const EdgeInsets.only(top: 1.0 * PdfPageFormat.cm),
+            child: Text(
+              'Page ${context.pageNumber} of ${context.pagesCount}',
+            ),
+          );
+        },
+        build: (final context) => [
+          Header(text: 'a', level: 1),
+          Text(LoremText().paragraph(600)),
+          Header(text: 'b', level: 1),
+        ],
+      ),
     );
   });
 


### PR DESCRIPTION
fixes #1120

i'm still trying to figure out what the fix is. i think my attempt here is at least partially correct, as it now creates an entry for both the wrong page number and the correct one:

![image](https://github.com/user-attachments/assets/3f4a1c92-d4ed-45b8-9005-f3c4f0a237a7)

i'm trying to just delay the rendering of the table of contents until after the correct page numbers for each section have been determined. i tried wrapping `TableOfContent` in a `DelayedWidget` but that didn't seem to have any effect. any guidance would be appreciated, thanks