### PR TITLE
fix: Prevent "Index out of range" error when reading simple glyphs in certain fonts

### DIFF
--- a/pdf/lib/src/pdf/font/ttf_parser.dart
+++ b/pdf/lib/src/pdf/font/ttf_parser.dart
@@ -437,6 +437,15 @@ class TtfParser {
 
     final start = tableOffsets[glyf_table]! + glyphOffsets[index];
 
+    // https://gist.github.com/smhanov/f009a02c00eb27d99479a1e37c1b3354
+    // apply check on line 757
+    // return the same TtfGlyphInfo object used when char is 32
+    // ie lib/src/pdf/font/ttf_writer.dart line 77
+    if (start >= tableSize[glyf_table]! + tableOffsets[glyf_table]! ||
+        start == 0) {
+      return TtfGlyphInfo(index, Uint8List(0), const <int>[]);
+    }
+
     final numberOfContours = bytes.getInt16(start);
     assert(numberOfContours >= -1);
 

--- a/pdf/lib/src/pdf/font/ttf_parser.dart
+++ b/pdf/lib/src/pdf/font/ttf_parser.dart
@@ -437,10 +437,6 @@ class TtfParser {
 
     final start = tableOffsets[glyf_table]! + glyphOffsets[index];
 
-    // https://gist.github.com/smhanov/f009a02c00eb27d99479a1e37c1b3354
-    // apply check on line 757
-    // return the same TtfGlyphInfo object used when char is 32
-    // ie lib/src/pdf/font/ttf_writer.dart line 77
     if (start >= tableSize[glyf_table]! + tableOffsets[glyf_table]! ||
         start == 0) {
       return TtfGlyphInfo(index, Uint8List(0), const <int>[]);


### PR DESCRIPTION
This PR addresses #1753 

Error message: RangeError (byteOffset): Index out of range: error

I encountered the above error when I attempted to add the **Dancing Script** font (downloadable from Google Fonts: [Dancing Script](https://fonts.google.com/specimen/Dancing+Script)) to my Flutter app.

I was able to trace the issue to **line 475** in the `TtfParser._readSimpleGlyph` method, which is called from `TtfParser.readGlyph`.

While investigating, I reviewed the referenced [JavaScript source](https://gist.github.com/smhanov/f009a02c00eb27d99479a1e37c1b3354), from which `TtfParser.readGlyph` was ported. I noticed that the following check on **line 757** of the JavaScript version was missing or incomplete in the Dart implementation:

```javascript
if (offset === 0 || offset >= table["offset"] + table["length"]) {
    return null;
}
```

The JavaScript source explains that an offset of zero is returned when the glyph has no outline (e.g., the space character), as seen on line 807. In the Dart version, the space character (Unicode 32) is specifically handled early on in line 76 of the `TtfWriter.withChars` method. However, other characters that meet the second condition (`offset >= table["offset"] + table["length"]`) cause the above error to be thrown—unlike the JavaScript version, which simply returns `null`.

### Fix

To resolve the issue, I added the missing check in the `TtfParser.readGlyph` method and return an empty `TtfGlyphInfo`, similar to what is returned for space characters (Unicode 32) in line 76 of `TtfWriter.withChars`.

