### PR TITLE
Improve performance of table layout

### DIFF
--- a/pdf/lib/src/widgets/table.dart
+++ b/pdf/lib/src/widgets/table.dart
@@ -348,9 +348,8 @@ class Table extends Widget with SpanningWidget {
     var index = 0;
 
     for (final row in children) {
-      for (final entry in row.children.asMap().entries) {
-        final index = entry.key;
-        final child = entry.value;
+      for (var index = 0; index < row.children.length; index++) {
+        final child = row.children[index];
         final columnWidth = columnWidths?[index] ?? defaultColumnWidth;
         final columnLayout = columnWidth.layout(child, context, constraints);
 


### PR DESCRIPTION
Thanks for creating this package!

We were looking into how to get the performance to be better and I ran into this:

Using asMap().entries to get the indexes while iterating a list is slow. So instead just use a good old c style for loop

This small change made a huge difference for us. Change the generation of on of our pdfs from 20s to 11s