### PR TITLE
Update according to breaking changes in the new AssetManifest API.

### DIFF
--- a/printing/CHANGELOG.md
+++ b/printing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.14.3
+
+- Update according to breaking changes in the new AssetManifest API [Pierre Fellendael]
+
 ## 5.14.2
 
 - Fix wasm dart.pub warning

--- a/printing/lib/src/fonts/manifest.dart
+++ b/printing/lib/src/fonts/manifest.dart
@@ -15,9 +15,8 @@
  */
 
 import 'dart:async';
-import 'dart:convert';
 
-import 'package:flutter/services.dart';
+import 'package:flutter/services.dart' as services;
 
 import '../mutex.dart';
 
@@ -40,19 +39,21 @@ mixin AssetManifest {
     try {
       if (!_ready) {
         try {
-          final jsonString = await rootBundle.loadString('AssetManifest.json');
-          final jsonData = json.decode(jsonString) as Map<String, dynamic>;
-          _assets.addAll(jsonData.keys);
+          final assetManifest = await services.AssetManifest.loadFromAssetBundle(services.rootBundle);
+          final assets = assetManifest.listAssets();
+          if (assets.isNotEmpty) {
+            _assets.addAll(assets);
+          }
         } catch (e) {
           assert(() {
             // ignore: avoid_print
             print(
-              'Error loading AssetManifest.json $e Try to call first:\nWidgetsFlutterBinding.ensureInitialized();',
+              'Error loading AssetManifest API: $e\n'
+                  'Make sure you called WidgetsFlutterBinding.ensureInitialized() in main()',
             );
             return true;
           }());
 
-          rootBundle.evict('AssetManifest.json');
           _failed = true;
           _ready = true;
           return false;

--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -15,7 +15,7 @@ topics:
   - print
   - printing
   - report
-version: 5.14.2
+version: 5.14.3
 
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
Prevents terminal error caused by missing AssetManifest.json during asset loading.

Removal of AssetManifest.json in "printing/lib/src/fonts/manifest.dart";
https://docs.flutter.dev/release/breaking-changes/asset-manifest-dot-json

Terminal error during asset loading with 'AssetManifest.json';
Error while trying to load an asset: Flutter Web engine failed to fetch "assets/AssetManifest.json". HTTP request succeeded, but the server responded with HTTP status 404.
Error loading AssetManifest.json Unable to load asset: "AssetManifest.json".
The asset does not exist or has empty data. Try to call first:
WidgetsFlutterBinding.ensureInitialized();