### PR TITLE
Fix RangeError in PdfPreviewRaster._raster

### DIFF
--- a/printing/lib/src/preview/raster.dart
+++ b/printing/lib/src/preview/raster.dart
@@ -196,10 +196,12 @@ mixin PdfPreviewRaster on State<PdfPreviewCustom> {
         pageNum++;
       }
 
-      for (var index = pageNum; index < pages.length; index++) {
-        pages[index].image.evict();
+      if (pageNum < pages.length) {
+        for (var index = pageNum; index < pages.length; index++) {
+          pages[index].image.evict();
+        }
+        pages.removeRange(pageNum, pages.length);
       }
-      pages.removeRange(pageNum, pages.length);
       if (mounted) {
         setState(() {});
       }


### PR DESCRIPTION
This fixes issue https://github.com/DavBfr/dart_pdf/issues/1891

Because `pageNum` is incremented at the end of the for loop, it could have the value `pages.length` after the for loop. In this case calling `pages.removeRange(pageNum, pages.length);` will throw a `RangeError`. To fix this, I added the check `if (pageNum < pagesLength)`.