### PR TITLE
Correctly calculating bounding boxes from children

### DIFF
--- a/pdf/lib/src/svg/group.dart
+++ b/pdf/lib/src/svg/group.dart
@@ -72,15 +72,15 @@ class SvgGroup extends SvgOperation {
 
   @override
   PdfRect boundingBox() {
-    var x = double.infinity, y = double.infinity, w = 0.0, h = 0.0;
+    var left = double.infinity, bottom = double.infinity, right = -double.infinity, top = -double.infinity;
     for (final child in children) {
       final b = child.boundingBox();
-      x = min(b.left, x);
-      y = min(b.bottom, y);
-      w = max(b.width, w);
-      h = max(b.height, w);
+      left = min(b.left, left);
+      bottom = min(b.bottom, bottom);
+      right = max(b.right, right);
+      top = max(b.top, top);
     }
 
-    return PdfRect(x, y, w, h);
+    return PdfRect.fromLBRT(left, bottom, right, top);
   }
 }

--- a/pdf/lib/src/svg/text.dart
+++ b/pdf/lib/src/svg/text.dart
@@ -180,15 +180,15 @@ class SvgText extends SvgOperation {
   @override
   PdfRect boundingBox() {
     final b = metrics.toPdfRect();
-    var x = b.left, y = b.bottom, w = b.width, h = b.height;
+    var left = b.left, bottom = b.bottom, right = b.right, top = b.top;
     for (final child in tspan) {
       final b = child.boundingBox();
-      x = min(b.left, x);
-      y = min(b.bottom, y);
-      w = max(b.width, w);
-      h = max(b.height, w);
+      left = min(b.left, left);
+      bottom = min(b.bottom, bottom);
+      right = max(b.right, right);
+      top = max(b.top, top);
     }
 
-    return PdfRect(x, y, w, h);
+    return PdfRect.fromLBRT(left, bottom, right, top);
   }
 }


### PR DESCRIPTION
The enclosing bounding boxes incorrectly check against the width and height, as opposed the right and top edges.

Given only child objects:
{left: 0, bottom: 0, width: 100, height: 100}
{left: 90, bottom: 90, width: 20, height: 20}

The prior implementation will incorrectly, return:
{left: 0, bottom: 0, width: 100, height: 100}

Instead of:
{left: 0, bottom: 0, width: 110, height: 110}

Adjustments have also been made to accommodate negative origins correctly.