### PR TITLE
bump version Image

### DIFF
--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   http: ">=0.13.0 <2.0.0"
-  image: ">=4.1.0 <4.6.0"
+  image: ">=4.1.0 <4.7.0"
   meta: ">=1.3.0 <2.0.0"
   pdf: ^3.10.0
   pdf_widget_wrapper: '>=1.0.4 <2.0.0'


### PR DESCRIPTION
Package is not compatible with recent update 4.6.0 of image package.  
`Because printing 5.14.2 depends on image >=4.1.0 <4.6.0 and no versions of printing match >5.14.2 <6.0.0, printing ^5.14.2 requires image >=4.1.0 <4.6.0.`

Did update image dependency.