### PR TITLE
feat: add CMYK and Adobe APP14 JPEG support

### DIFF
--- a/pdf/lib/src/pdf/exif.dart
+++ b/pdf/lib/src/pdf/exif.dart
@@ -33,6 +33,7 @@ class PdfJpegInfo {
     int? width;
     int? height;
     int? color;
+    int? adobeColorTransform;
     var offset = 0;
     while (offset < buffer.lengthInBytes) {
       while (buffer.getUint8(offset) == 0xff) {
@@ -67,6 +68,18 @@ class PdfJpegInfo {
         color = buffer.getUint8(offset + 5);
         break;
       }
+
+      // Adobe APP14 marker
+      if (mrkr == 0xee && len >= 14) {
+        if (buffer.getUint8(offset) == 0x41 &&
+            buffer.getUint8(offset + 1) == 0x64 &&
+            buffer.getUint8(offset + 2) == 0x6F &&
+            buffer.getUint8(offset + 3) == 0x62 &&
+            buffer.getUint8(offset + 4) == 0x65) {
+          adobeColorTransform = buffer.getUint8(offset + 11);
+        }
+      }
+
       offset += len - 2;
     }
 
@@ -76,10 +89,12 @@ class PdfJpegInfo {
 
     final tags = _findExifInJpeg(buffer);
 
-    return PdfJpegInfo._(width, height, color, tags);
+    return PdfJpegInfo._(width, height, color, adobeColorTransform, tags);
   }
 
-  PdfJpegInfo._(this.width, this.height, this._color, this.tags);
+  PdfJpegInfo._(
+      this.width, this.height, this._color, this._adobeColorTransform,
+      this.tags);
 
   /// Width of the image
   final int? width;
@@ -89,8 +104,18 @@ class PdfJpegInfo {
 
   final int? _color;
 
+  final int? _adobeColorTransform;
+
   /// Is the image color or greyscale
   bool get isRGB => _color == 3;
+
+  /// Whether the image uses CMYK color space (4 components)
+  bool get isCMYK => _color == 4;
+
+  /// Whether this CMYK JPEG uses inverted color values (Adobe YCCK convention).
+  /// Returns true when there is no Adobe APP14 marker (assumed inverted, the
+  /// most common case) or when the marker explicitly indicates YCCK encoding.
+  bool get isCMYKInverted => isCMYK && _adobeColorTransform != 0;
 
   /// Exif tags discovered
   final Map<PdfExifTag, dynamic>? tags;

--- a/pdf/lib/src/pdf/obj/image.dart
+++ b/pdf/lib/src/pdf/obj/image.dart
@@ -20,6 +20,7 @@ import 'package:image/image.dart' as im;
 
 import '../document.dart';
 import '../exif.dart';
+import '../format/array.dart';
 import '../format/indirect.dart';
 import '../format/name.dart';
 import '../format/num.dart';
@@ -143,7 +144,15 @@ class PdfImage extends PdfXObject {
     im.params['/Intent'] = const PdfName('/RelativeColorimetric');
     im.params['/Filter'] = const PdfName('/DCTDecode');
 
-    if (info.isRGB) {
+    if (info.isCMYK) {
+      im.params['/ColorSpace'] = const PdfName('/DeviceCMYK');
+      if (info.isCMYKInverted) {
+        // CMYK JPEGs from Adobe use inverted values (YCCK encoding).
+        // The /Decode array inverts each component back to proper CMYK.
+        im.params['/Decode'] =
+            PdfArray.fromNum(<int>[1, 0, 1, 0, 1, 0, 1, 0]);
+      }
+    } else if (info.isRGB) {
       im.params['/ColorSpace'] = const PdfName('/DeviceRGB');
     } else {
       im.params['/ColorSpace'] = const PdfName('/DeviceGray');


### PR DESCRIPTION
- Parse Adobe APP14 markers to support CMYK and inverted color space detection in JPEG images.
- Implement CMYK color space support and handle inverted Adobe JPEG color decoding.