### PR TITLE
fix: handle compound glyph offset calculation and null sub-glyph index

### DIFF
--- a/pdf/lib/src/pdf/font/ttf_writer.dart
+++ b/pdf/lib/src/pdf/font/ttf_writer.dart
@@ -42,7 +42,10 @@ class TtfWriter {
 
   void _updateCompoundGlyph(TtfGlyphInfo glyph, Map<int, int?> compoundMap) {
     const arg1And2AreWords = 1;
+    const weHaveAScale = 8;
     const moreComponents = 32;
+    const weHaveAnXAndYScale = 64;
+    const weHaveATwoByTwo = 128;
 
     var offset = 10;
     final bytes = glyph.data.buffer
@@ -50,10 +53,23 @@ class TtfWriter {
     var flags = moreComponents;
 
     while (flags & moreComponents != 0) {
+      if (offset + 4 > bytes.lengthInBytes) {
+        break;
+      }
       flags = bytes.getUint16(offset);
       final glyphIndex = bytes.getUint16(offset + 2);
-      bytes.setUint16(offset + 2, compoundMap[glyphIndex]!);
+      final newIndex = compoundMap[glyphIndex];
+      if (newIndex != null) {
+        bytes.setUint16(offset + 2, newIndex);
+      }
       offset += (flags & arg1And2AreWords != 0) ? 8 : 6;
+      if (flags & weHaveAScale != 0) {
+        offset += 2;
+      } else if (flags & weHaveAnXAndYScale != 0) {
+        offset += 4;
+      } else if (flags & weHaveATwoByTwo != 0) {
+        offset += 8;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes crash in `TtfWriter._updateCompoundGlyph` when generating PDFs with certain TTF fonts (e.g. Inter).

Two issues addressed:

- **Null assertion crash**: `compoundMap[glyphIndex]!` crashes when a compound glyph references a sub-glyph index not present in the map. Now gracefully skips the update if the index is missing.

- **Incorrect offset calculation**: The offset advancement only accounted for `ARG_1_AND_2_ARE_WORDS` but ignored `WE_HAVE_A_SCALE` (+2 bytes), `WE_HAVE_AN_X_AND_Y_SCALE` (+4 bytes), and `WE_HAVE_A_TWO_BY_TWO` (+8 bytes) transformation flags per the [TrueType compound glyph spec](https://learn.microsoft.com/en-us/typography/opentype/spec/glyf#composite-glyph-description). This caused offset drift, reading invalid data for subsequent components and eventual `RangeError`.

- **Bounds check**: Added a boundary check to prevent reading past the end of glyph data.

## Stack trace that was occurring

```
#0      TtfWriter._updateCompoundGlyph (package:pdf/src/pdf/font/ttf_writer.dart:55:58)
#1      TtfWriter.withChars (package:pdf/src/pdf/font/ttf_writer.dart:130:9)
#2      PdfTtfFont._buildType0 (package:pdf/src/pdf/obj/ttffont.dart:121:28)
#3      PdfTtfFont.prepare (package:pdf/src/pdf/obj/ttffont.dart:162:7)
#4      PdfDocument._write (package:pdf/src/pdf/document.dart:230:10)
#5      PdfDocument.save (package:pdf/src/pdf/document.dart:278:13)
```

## Test plan

- Tested with Inter-Regular.ttf and Inter-SemiBold.ttf fonts that previously caused the crash
- PDF generation now completes successfully