### PR TITLE
Feature: Windows 10/11 Modern Print Dialog Support

### DIFF
--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -159,6 +159,7 @@ class PrintingPlugin extends PrintingPlatform {
     bool usePrinterSettings,
     OutputType outputType,
     bool forceCustomPrintPaper,
+    bool windowsModernDialog,
   ) async {
     late Uint8List result;
     try {

--- a/printing/lib/src/interface.dart
+++ b/printing/lib/src/interface.dart
@@ -69,6 +69,7 @@ abstract class PrintingPlatform extends PlatformInterface {
     bool usePrinterSettings,
     OutputType outputType,
     bool forceCustomPrintPaper,
+    bool windowsModernDialog,
   );
 
   /// Enumerate the available printers on the system.

--- a/printing/lib/src/method_channel.dart
+++ b/printing/lib/src/method_channel.dart
@@ -180,6 +180,7 @@ class MethodChannelPrinting extends PrintingPlatform {
     bool usePrinterSettings,
     OutputType outputType,
     bool forceCustomPrintPaper,
+    bool windowsModernDialog,
   ) async {
     final job = _printJobs.add(
       onCompleted: Completer<bool>(),
@@ -200,6 +201,7 @@ class MethodChannelPrinting extends PrintingPlatform {
       'usePrinterSettings': usePrinterSettings,
       'outputType': outputType.index,
       'forceCustomPrintPaper': forceCustomPrintPaper,
+      if (windowsModernDialog) 'windowsModernDialog': windowsModernDialog,
     };
 
     await _channel.invokeMethod<int>('printPdf', params);

--- a/printing/lib/src/printing.dart
+++ b/printing/lib/src/printing.dart
@@ -57,6 +57,7 @@ mixin Printing {
     bool usePrinterSettings = false,
     OutputType outputType = OutputType.generic,
     bool forceCustomPrintPaper = false,
+    bool windowsModernDialog = false,
   }) {
     return PrintingPlatform.instance.layoutPdf(
       null,
@@ -67,6 +68,7 @@ mixin Printing {
       usePrinterSettings,
       outputType,
       forceCustomPrintPaper,
+      windowsModernDialog,
     );
   }
 
@@ -164,6 +166,7 @@ mixin Printing {
     bool usePrinterSettings = false,
     OutputType outputType = OutputType.generic,
     bool forceCustomPrintPaper = false,
+    bool windowsModernDialog = false,
   }) {
     return PrintingPlatform.instance.layoutPdf(
       printer,
@@ -174,6 +177,7 @@ mixin Printing {
       usePrinterSettings,
       outputType,
       forceCustomPrintPaper,
+      windowsModernDialog,
     );
   }
 

--- a/printing/test/printing_test.dart
+++ b/printing/test/printing_test.dart
@@ -99,6 +99,7 @@ class MockPrinting extends Mock
     bool usePrinterSettings,
     OutputType outputType,
     bool forceCustomPrintPaper,
+    bool windowsModernDialog,
   ) async => true;
 
   @override

--- a/printing/windows/print_job.cpp
+++ b/printing/windows/print_job.cpp
@@ -78,7 +78,8 @@ bool PrintJob::printPdf(const std::string& name,
                         std::string printer,
                         double width,
                         double height,
-                        bool usePrinterSettings) {
+                        bool usePrinterSettings,
+                        bool windowsModernDialog) {
   documentName = name;
 
   std::size_t dmSize = sizeof(DEVMODE);
@@ -112,39 +113,71 @@ bool PrintJob::printPdf(const std::string& name,
   }
 
   if (printer.empty()) {
-    PRINTDLG pd;
+    if (windowsModernDialog) {
+      // --- MODERN OPTION (PrintDlgEx) ---
+      PRINTDLGEX pdx = {0};
+      pdx.lStructSize = sizeof(PRINTDLGEX);
+      pdx.hwndOwner = GetActiveWindow();
+      pdx.hDevMode = dm;
+      dm = nullptr; // dialog takes ownership; may replace with new alloc
+      pdx.hDevNames = nullptr;
+      pdx.hDC = nullptr;
+      
+      // Flags: Use PD_RETURNDC to get the context we need for PDFium
+      pdx.Flags = PD_RETURNDC | PD_USEDEVMODECOPIESANDCOLLATE | PD_NOPAGENUMS | PD_NOSELECTION;
+      
+      pdx.nStartPage = START_PAGE_GENERAL;
+      pdx.nMaxPageRanges = 1;
+      PRINTPAGERANGE ranges[1] = {{1, 1}}; // Required structure for PDX
+      pdx.lpPageRanges = ranges;
+      
+      HRESULT hr = PrintDlgEx(&pdx);
 
-    // Initialize PRINTDLG
-    ZeroMemory(&pd, sizeof(pd));
-    pd.lStructSize = sizeof(pd);
+      // Check if the user actually clicked "Print"
+      if (hr == S_OK && pdx.dwResultAction == PD_RESULT_PRINT) {
+        this->hDC = pdx.hDC;
+        this->hDevMode = pdx.hDevMode;
+        this->hDevNames = pdx.hDevNames;
+        //success = true;
+      } else {
+        // User cancelled or error occurred — notify Dart so its future completes.
+        if (pdx.hDC) DeleteDC(pdx.hDC);
+        if (pdx.hDevMode) GlobalFree(pdx.hDevMode);
+        if (pdx.hDevNames) GlobalFree(pdx.hDevNames);
+        printing->onCompleted(this, false, "");
+        return false;
+      }
+    } else {
+      // --- CLASSIC DEFAULT  ---
+      PRINTDLG pd;
+      ZeroMemory(&pd, sizeof(pd));
+      pd.lStructSize = sizeof(pd);
+      pd.hwndOwner = nullptr;
+      pd.hDevMode = dm;
+      pd.hDevNames = nullptr;
+      pd.hDC = nullptr;
+      pd.Flags = PD_USEDEVMODECOPIES | PD_RETURNDC | PD_PRINTSETUP |
+                 PD_NOSELECTION | PD_NOPAGENUMS;
+      pd.nCopies = 1;
+      pd.nFromPage = 0xFFFF;
+      pd.nToPage = 0xFFFF;
+      pd.nMinPage = 1;
+      pd.nMaxPage = 0xFFFF;
 
-    // Initialize PRINTDLG
-    pd.hwndOwner = nullptr;
-    pd.hDevMode = dm;
-    pd.hDevNames = nullptr;  // Don't forget to free or store hDevNames.
-    pd.hDC = nullptr;
-    pd.Flags = PD_USEDEVMODECOPIES | PD_RETURNDC | PD_PRINTSETUP |
-               PD_NOSELECTION | PD_NOPAGENUMS;
-    pd.nCopies = 1;
-    pd.nFromPage = 0xFFFF;
-    pd.nToPage = 0xFFFF;
-    pd.nMinPage = 1;
-    pd.nMaxPage = 0xFFFF;
+      auto r = PrintDlg(&pd);
 
-    auto r = PrintDlg(&pd);
+      if (r != 1) {
+        printing->onCompleted(this, false, "");
+        DeleteDC(hDC);
+        GlobalFree(hDevNames);
+        GlobalFree(hDevMode);
+        return true;
+      }
 
-    if (r != 1) {
-      printing->onCompleted(this, false, "");
-      DeleteDC(hDC);
-      GlobalFree(hDevNames);
-      ClosePrinter(hDevMode);
-      return true;
+      hDC = pd.hDC;
+      hDevMode = pd.hDevMode;
+      hDevNames = pd.hDevNames;
     }
-
-    hDC = pd.hDC;
-    hDevMode = pd.hDevMode;
-    hDevNames = pd.hDevNames;
-
   } else {
     hDC = CreateDC(TEXT("WINSPOOL"), fromUtf8(printer).c_str(), nullptr, dm);
     if (!hDC) {
@@ -280,7 +313,7 @@ void PrintJob::writeJob(std::vector<uint8_t> data) {
 
   DeleteDC(hDC);
   GlobalFree(hDevNames);
-  ClosePrinter(hDevMode);
+  GlobalFree(hDevMode);
 
   printing->onCompleted(this, true, "");
 }

--- a/printing/windows/print_job.h
+++ b/printing/windows/print_job.h
@@ -75,7 +75,8 @@ class PrintJob {
                 std::string printer,
                 double width,
                 double height,
-                bool usePrinterSettings);
+                bool usePrinterSettings,
+                bool windowsModernDialog);
 
   void writeJob(std::vector<uint8_t> data);
 

--- a/printing/windows/printing_plugin.cpp
+++ b/printing/windows/printing_plugin.cpp
@@ -81,11 +81,16 @@ class PrintingPlugin : public flutter::Plugin {
       auto usePrinterSettings = std::get<bool>(
           arguments->find(flutter::EncodableValue("usePrinterSettings"))
               ->second);
+      bool windowsModernDialog = false;
+      auto it = arguments->find(flutter::EncodableValue("windowsModernDialog"));
+      if (it != arguments->end() && !it->second.IsNull()) {
+        windowsModernDialog = std::get<bool>(it->second);
+      }
       auto vJob = arguments->find(flutter::EncodableValue("job"));
       auto jobNum = vJob != arguments->end() ? std::get<int>(vJob->second) : -1;
       auto job = new PrintJob{&printing, jobNum};
       auto res =
-          job->printPdf(name, printer, width, height, usePrinterSettings);
+          job->printPdf(name, printer, width, height, usePrinterSettings, windowsModernDialog);
       if (!res) {
         delete job;
       }


### PR DESCRIPTION
### 🚀 Feature: Windows 10/11 Modern Print Dialog Support (`PrintDlgEx`)

**Overview**
Currently, the [printing](cci:1://file:///Users/joaocarvalho/Code/itowin/dart_pdf/printing/windows/print_job.cpp:431:0-436:1) package uses the legacy `PrintDlg` API on Windows, which opens the old Windows 95-style print dialog. This PR adds support for `PrintDlgEx`, allowing developers to opt-in to the modern Windows print UI.

**Key Changes:**
- **New Parameter:** Added a `windowsModernDialog` boolean parameter (defaults to `false`) to [layoutPdf](cci:1://file:///Users/joaocarvalho/Code/itowin/dart_pdf/printing/lib/src/interface.dart:62:2-72:3) and [directPrintPdf](cci:1://file:///Users/joaocarvalho/Code/itowin/dart_pdf/printing/lib/src/printing.dart:138:2-181:3). 
- **`PrintDlgEx` Integration:** When `windowsModernDialog` is true, the native Windows implementation now calls the modern `PrintDlgEx` API instead of the legacy `PrintDlg`.
- **Memory Leak Fix:** Fixed a pre-existing memory leak in the classic dialog's cancel path where `ClosePrinter()` was incorrectly used instead of `GlobalFree()` on the `DEVMODE` handle. The modern cancel path also properly frees native resources and correctly completes the Dart future with `false`.

**Behavior by OS Version:**
- **Windows 10:** Opens the modern tabbed dialog.
- **Windows 11 (22H2+):** Opens the completely redesigned, simplified Windows 11 system print dialog. Note: Microsoft's new dialog unconditionally disables preview for Win32 apps (showing "This app doesn't support print preview") and ignores `IPrintDialogCallback`, but printing functionality works perfectly.