### PR TITLE
fix(ttf): name the offending codepoint when no glyph is available

### DIFF
--- a/pdf/lib/src/pdf/font/ttf_writer.dart
+++ b/pdf/lib/src/pdf/font/ttf_writer.dart
@@ -130,7 +130,24 @@ class TtfWriter {
     for (final char in chars) {
       final glyphsIndex = charMap[char];
       if (glyphsIndex != null) {
-        glyphsInfo.add(glyphsMap[glyphsIndex] ?? glyphsMap.values.first);
+        final glyph = glyphsMap[glyphsIndex];
+        if (glyph != null) {
+          glyphsInfo.add(glyph);
+        } else if (glyphsMap.isNotEmpty) {
+          glyphsInfo.add(glyphsMap.values.first);
+        } else {
+          // The font has no glyph reachable for [char] AND every other glyph in the
+          // subset has already been consumed, so `glyphsMap.values.first` would throw
+          // `Bad state: No element`. Surface a clearer diagnostic that names the
+          // offending codepoint — this is typically a font/charset mismatch
+          // (e.g. Arabic Presentation Forms in a font with no Presentation glyphs).
+          throw Exception(
+            "Missing glyph for character '${String.fromCharCode(char)}' "
+            '(U+${char.toRadixString(16).toUpperCase().padLeft(4, '0')}) '
+            'in font ${ttf.fontName}. Use a font that includes this codepoint, '
+            "or strip/normalize the character before passing it to the PDF.",
+          );
+        }
         glyphsMap.remove(glyphsIndex);
       }
     }


### PR DESCRIPTION
`TtfWriter.withChars` falls back to `glyphsMap.values.first` when the requested glyph index isn't in the subset cache. If every glyph has already been consumed (e.g. a font that has no glyph for an Arabic Presentation Form codepoint AND no surrounding chars added other glyphs), that `.first` call throws the generic Dart-runtime error `Bad state: No element`, which gives the user zero clue what input triggered it.

Reformulate the fallback as an explicit if/else and, in the truly-empty case, raise a clearer exception that names the offending character and its Unicode codepoint (and the font that lacks it). The non-empty fallback path is preserved bit-for-bit — only the otherwise-untyped runtime crash is replaced.

Closes #1919.