### PR TITLE
Sync fork updates (incl. #1921/#1913) and Windows PDFium lifecycle fix

### DIFF
--- a/printing/ios/Classes/PrintJob.swift
+++ b/printing/ios/Classes/PrintJob.swift
@@ -84,7 +84,8 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
             controller.delegate = self
 
             let printInfo = UIPrintInfo.printInfo()
-            printInfo.jobName = jobName!
+            let strippedJobName = jobName!.hasSuffix(".pdf") ? String(jobName!.dropLast(4)) : jobName!
+            printInfo.jobName = strippedJobName
             printInfo.outputType = .general
             if orientation != nil {
                 printInfo.orientation = orientation!
@@ -185,7 +186,8 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
             orientation = UIPrintInfo.Orientation.landscape
         }
 
-        jobName = name
+        // Strip .pdf extension as UIPrintInteractionController appends it automatically
+        jobName = name.hasSuffix(".pdf") ? String(name.dropLast(4)) : name
         printerName = printerID
 
         let controller = UIPrintInteractionController.shared

--- a/printing/ios/Classes/PrintingPlugin.swift
+++ b/printing/ios/Classes/PrintingPlugin.swift
@@ -169,7 +169,9 @@ public class PrintingPlugin: NSObject, FlutterPlugin {
             "job": printJob.index,
         ] as [String: Any]
 
-        channel.invokeMethod("onLayout", arguments: arg)
+        DispatchQueue.main.async {
+            self.channel.invokeMethod("onLayout", arguments: arg)
+        }
     }
 
     /// send completion status to flutter
@@ -179,8 +181,10 @@ public class PrintingPlugin: NSObject, FlutterPlugin {
             "error": error as Any,
             "job": printJob.index,
         ]
-        channel.invokeMethod("onCompleted", arguments: data)
         jobs.removeValue(forKey: UInt32(printJob.index))
+        DispatchQueue.main.async {
+            self.channel.invokeMethod("onCompleted", arguments: data)
+        }
     }
 
     /// send html to pdf data result to flutter
@@ -189,7 +193,9 @@ public class PrintingPlugin: NSObject, FlutterPlugin {
             "doc": FlutterStandardTypedData(bytes: pdfData),
             "job": printJob.index,
         ]
-        channel.invokeMethod("onHtmlRendered", arguments: data)
+        DispatchQueue.main.async {
+            self.channel.invokeMethod("onHtmlRendered", arguments: data)
+        }
     }
 
     /// send html to pdf conversion error to flutter
@@ -198,7 +204,9 @@ public class PrintingPlugin: NSObject, FlutterPlugin {
             "error": error,
             "job": printJob.index,
         ]
-        channel.invokeMethod("onHtmlError", arguments: data)
+        DispatchQueue.main.async {
+            self.channel.invokeMethod("onHtmlError", arguments: data)
+        }
     }
 
     /// send pdf to raster data result to flutter
@@ -209,7 +217,9 @@ public class PrintingPlugin: NSObject, FlutterPlugin {
             "height": height,
             "job": printJob.index,
         ]
-        channel.invokeMethod("onPageRasterized", arguments: data)
+        DispatchQueue.main.async {
+            self.channel.invokeMethod("onPageRasterized", arguments: data)
+        }
     }
 
     public func onPageRasterEnd(printJob: PrintJob, error: String?) {
@@ -217,6 +227,8 @@ public class PrintingPlugin: NSObject, FlutterPlugin {
             "job": printJob.index,
             "error": error as Any,
         ]
-        channel.invokeMethod("onPageRasterEnd", arguments: data)
+        DispatchQueue.main.async {
+            self.channel.invokeMethod("onPageRasterEnd", arguments: data)
+        }
     }
 }

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -99,10 +99,10 @@ class PrintingPlugin extends PrintingPlatform {
       } else {
         final pdfJsVersion =
             web.window.hasProperty(_dartPdfJsVersion.toJS).toDart
-            ? web.window
-                  .getProperty<js.JSString?>(_dartPdfJsVersion.toJS)!
-                  .toDart
-            : _pdfJsVersion;
+                ? web.window
+                    .getProperty<js.JSString?>(_dartPdfJsVersion.toJS)!
+                    .toDart
+                : _pdfJsVersion;
         _pdfJsUrlBase = '$_pdfJsCdnPath@$pdfJsVersion/build/';
       }
 
@@ -159,6 +159,7 @@ class PrintingPlugin extends PrintingPlatform {
     bool usePrinterSettings,
     OutputType outputType,
     bool forceCustomPrintPaper,
+    bool windowsModernDialog,
   ) async {
     late Uint8List result;
     try {
@@ -406,7 +407,7 @@ class PrintingPlugin extends PrintingPlatform {
 
 class _WebPdfRaster extends PdfRaster {
   _WebPdfRaster(int width, int height, this.png)
-    : super(width, height, Uint8List(0));
+      : super(width, height, Uint8List(0));
 
   final Uint8List png;
 

--- a/printing/lib/src/interface.dart
+++ b/printing/lib/src/interface.dart
@@ -69,6 +69,7 @@ abstract class PrintingPlatform extends PlatformInterface {
     bool usePrinterSettings,
     OutputType outputType,
     bool forceCustomPrintPaper,
+    bool useModernDialog,
   );
 
   /// Enumerate the available printers on the system.

--- a/printing/lib/src/interface.dart
+++ b/printing/lib/src/interface.dart
@@ -69,7 +69,7 @@ abstract class PrintingPlatform extends PlatformInterface {
     bool usePrinterSettings,
     OutputType outputType,
     bool forceCustomPrintPaper,
-    bool useModernDialog,
+    bool windowsModernDialog,
   );
 
   /// Enumerate the available printers on the system.

--- a/printing/lib/src/method_channel.dart
+++ b/printing/lib/src/method_channel.dart
@@ -183,7 +183,7 @@ class MethodChannelPrinting extends PrintingPlatform {
     bool usePrinterSettings,
     OutputType outputType,
     bool forceCustomPrintPaper,
-    bool useModernDialog,
+    bool windowsModernDialog,
   ) async {
     final job = _printJobs.add(
       onCompleted: Completer<bool>(),
@@ -204,7 +204,7 @@ class MethodChannelPrinting extends PrintingPlatform {
       'usePrinterSettings': usePrinterSettings,
       'outputType': outputType.index,
       'forceCustomPrintPaper': forceCustomPrintPaper,
-      'useModernDialog': useModernDialog,
+      if (windowsModernDialog) 'windowsModernDialog': windowsModernDialog,
     };
 
     await _channel.invokeMethod<int>('printPdf', params);

--- a/printing/lib/src/method_channel.dart
+++ b/printing/lib/src/method_channel.dart
@@ -183,6 +183,7 @@ class MethodChannelPrinting extends PrintingPlatform {
     bool usePrinterSettings,
     OutputType outputType,
     bool forceCustomPrintPaper,
+    bool useModernDialog,
   ) async {
     final job = _printJobs.add(
       onCompleted: Completer<bool>(),
@@ -203,6 +204,7 @@ class MethodChannelPrinting extends PrintingPlatform {
       'usePrinterSettings': usePrinterSettings,
       'outputType': outputType.index,
       'forceCustomPrintPaper': forceCustomPrintPaper,
+      'useModernDialog': useModernDialog,
     };
 
     await _channel.invokeMethod<int>('printPdf', params);

--- a/printing/lib/src/print_job.dart
+++ b/printing/lib/src/print_job.dart
@@ -15,6 +15,7 @@
  */
 
 import 'dart:async';
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'callback.dart';
@@ -57,7 +58,7 @@ class PrintJobs {
   /// Create a list print jobs
   PrintJobs();
 
-  static var _currentIndex = 0;
+  static int _currentIndex = Random().nextInt(0x7FFFFFFF);
 
   final _printJobs = <int, PrintJob>{};
 

--- a/printing/lib/src/printing.dart
+++ b/printing/lib/src/printing.dart
@@ -57,6 +57,7 @@ mixin Printing {
     bool usePrinterSettings = false,
     OutputType outputType = OutputType.generic,
     bool forceCustomPrintPaper = false,
+    bool useModernDialog = false,
   }) {
     return PrintingPlatform.instance.layoutPdf(
       null,
@@ -67,6 +68,7 @@ mixin Printing {
       usePrinterSettings,
       outputType,
       forceCustomPrintPaper,
+      useModernDialog,
     );
   }
 
@@ -164,6 +166,7 @@ mixin Printing {
     bool usePrinterSettings = false,
     OutputType outputType = OutputType.generic,
     bool forceCustomPrintPaper = false,
+    bool useModernDialog = false,
   }) {
     return PrintingPlatform.instance.layoutPdf(
       printer,
@@ -174,6 +177,7 @@ mixin Printing {
       usePrinterSettings,
       outputType,
       forceCustomPrintPaper,
+      useModernDialog,
     );
   }
 

--- a/printing/lib/src/printing.dart
+++ b/printing/lib/src/printing.dart
@@ -57,7 +57,7 @@ mixin Printing {
     bool usePrinterSettings = false,
     OutputType outputType = OutputType.generic,
     bool forceCustomPrintPaper = false,
-    bool useModernDialog = false,
+    bool windowsModernDialog = false,
   }) {
     return PrintingPlatform.instance.layoutPdf(
       null,
@@ -68,7 +68,7 @@ mixin Printing {
       usePrinterSettings,
       outputType,
       forceCustomPrintPaper,
-      useModernDialog,
+      windowsModernDialog,
     );
   }
 
@@ -166,7 +166,7 @@ mixin Printing {
     bool usePrinterSettings = false,
     OutputType outputType = OutputType.generic,
     bool forceCustomPrintPaper = false,
-    bool useModernDialog = false,
+    bool windowsModernDialog = false,
   }) {
     return PrintingPlatform.instance.layoutPdf(
       printer,
@@ -177,7 +177,7 @@ mixin Printing {
       usePrinterSettings,
       outputType,
       forceCustomPrintPaper,
-      useModernDialog,
+      windowsModernDialog,
     );
   }
 

--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -30,8 +30,16 @@ dependencies:
   http: ">=0.13.0 <2.0.0"
   image: ">=4.1.0 <=5.0.0"
   meta: ">=1.3.0 <2.0.0"
-  pdf: ^3.10.0
-  pdf_widget_wrapper: '>=1.0.4 <2.0.0'
+  pdf:
+    git:
+      url: https://github.com/ptech/dart_pdf.git
+      ref: v3.11.3-ptech # Fix thread issues on iOS and MacOS printing plugin
+      path: pdf
+  pdf_widget_wrapper:
+    git:
+      url: https://github.com/ptech/dart_pdf.git
+      ref: v1.0.4-ptech # Fix thread issues on iOS and MacOS printing plugin
+      path: widget_wrapper
   plugin_platform_interface: ^2.1.0
   web: ^1.0.0
 

--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -30,16 +30,8 @@ dependencies:
   http: ">=0.13.0 <2.0.0"
   image: ">=4.1.0 <=5.0.0"
   meta: ">=1.3.0 <2.0.0"
-  pdf:
-    git:
-      url: https://github.com/ptech/dart_pdf.git
-      ref: v3.11.3-ptech # Fix thread issues on iOS and MacOS printing plugin
-      path: pdf
-  pdf_widget_wrapper:
-    git:
-      url: https://github.com/ptech/dart_pdf.git
-      ref: v1.0.4-ptech # Fix thread issues on iOS and MacOS printing plugin
-      path: widget_wrapper
+  pdf: ^3.12.0
+  pdf_widget_wrapper: '>=1.0.4 <2.0.0'
   plugin_platform_interface: ^2.1.0
   web: ^1.0.0
 
@@ -53,7 +45,7 @@ dependency_overrides:
   pdf:
     path: ../pdf
   pdf_widget_wrapper:
-   path: ../widget_wrapper
+    path: ../widget_wrapper
 
 flutter:
   plugin:

--- a/printing/test/printing_test.dart
+++ b/printing/test/printing_test.dart
@@ -99,7 +99,9 @@ class MockPrinting extends Mock
     bool usePrinterSettings,
     OutputType outputType,
     bool forceCustomPrintPaper,
-  ) async => true;
+    bool windowsModernDialog,
+  ) async =>
+      true;
 
   @override
   Future<bool> sharePdf(
@@ -109,7 +111,8 @@ class MockPrinting extends Mock
     String? subject,
     String? body,
     List<String>? emails,
-  ) async => true;
+  ) async =>
+      true;
 
   @override
   Future<Printer?> pickPrinter(Rect bounds) async => null;

--- a/printing/windows/print_job.cpp
+++ b/printing/windows/print_job.cpp
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@
  */
 
 #include "print_job.h"
-
 #include "printing.h"
 
 #include <fpdfview.h>
@@ -58,7 +57,7 @@ std::string toUtf8(TCHAR* tstr) {
 
 std::wstring fromUtf8(std::string str) {
   auto len = MultiByteToWideChar(CP_UTF8, 0, str.c_str(),
-                                 static_cast<int>(str.length()), nullptr, 0);
+                                  static_cast<int>(str.length()), nullptr, 0);
   if (len <= 0) {
     return L"";
   }
@@ -78,7 +77,9 @@ bool PrintJob::printPdf(const std::string& name,
                         std::string printer,
                         double width,
                         double height,
-                        bool usePrinterSettings) {
+                        bool usePrinterSettings,
+                        bool useModernDialog) {
+  
   documentName = name;
 
   std::size_t dmSize = sizeof(DEVMODE);
@@ -86,7 +87,7 @@ bool PrintJob::printPdf(const std::string& name,
 
   if (!printer.empty()) {
     dmExtra = DeviceCapabilities(fromUtf8(printer).c_str(), NULL, DC_EXTRA,
-                                 NULL, NULL);
+                                  NULL, NULL);
   }
 
   auto dm = static_cast<DEVMODE*>(GlobalAlloc(0, dmSize + dmExtra));
@@ -112,39 +113,71 @@ bool PrintJob::printPdf(const std::string& name,
   }
 
   if (printer.empty()) {
-    PRINTDLG pd;
+    if (useModernDialog) {
+      // --- MODERN OPTION (PrintDlgEx) ---
+      PRINTDLGEX pdx = {0};
+      pdx.lStructSize = sizeof(PRINTDLGEX);
+      pdx.hwndOwner = GetActiveWindow();
+      pdx.hDevMode = dm;
+      dm = nullptr; // dialog takes ownership; may replace with new alloc
+      pdx.hDevNames = nullptr;
+      pdx.hDC = nullptr;
+      
+      // Flags: Use PD_RETURNDC to get the context we need for PDFium
+      pdx.Flags = PD_RETURNDC | PD_USEDEVMODECOPIESANDCOLLATE | PD_NOPAGENUMS | PD_NOSELECTION;
+      
+      pdx.nStartPage = START_PAGE_GENERAL;
+      pdx.nMaxPageRanges = 1;
+      PRINTPAGERANGE ranges[1] = {{1, 1}}; // Required structure for PDX
+      pdx.lpPageRanges = ranges;
+      
+      HRESULT hr = PrintDlgEx(&pdx);
 
-    // Initialize PRINTDLG
-    ZeroMemory(&pd, sizeof(pd));
-    pd.lStructSize = sizeof(pd);
+      // Check if the user actually clicked "Print"
+      if (hr == S_OK && pdx.dwResultAction == PD_RESULT_PRINT) {
+        this->hDC = pdx.hDC;
+        this->hDevMode = pdx.hDevMode;
+        this->hDevNames = pdx.hDevNames;
+        //success = true;
+      } else {
+        // User cancelled or error occurred — notify Dart so its future completes.
+        if (pdx.hDC) DeleteDC(pdx.hDC);
+        if (pdx.hDevMode) GlobalFree(pdx.hDevMode);
+        if (pdx.hDevNames) GlobalFree(pdx.hDevNames);
+        printing->onCompleted(this, false, "");
+        return false;
+      }
+    } else {
+      // --- CLASSIC DEFAULT  ---
+      PRINTDLG pd;
+      ZeroMemory(&pd, sizeof(pd));
+      pd.lStructSize = sizeof(pd);
+      pd.hwndOwner = nullptr;
+      pd.hDevMode = dm;
+      pd.hDevNames = nullptr;
+      pd.hDC = nullptr;
+      pd.Flags = PD_USEDEVMODECOPIES | PD_RETURNDC | PD_PRINTSETUP |
+                 PD_NOSELECTION | PD_NOPAGENUMS;
+      pd.nCopies = 1;
+      pd.nFromPage = 0xFFFF;
+      pd.nToPage = 0xFFFF;
+      pd.nMinPage = 1;
+      pd.nMaxPage = 0xFFFF;
 
-    // Initialize PRINTDLG
-    pd.hwndOwner = nullptr;
-    pd.hDevMode = dm;
-    pd.hDevNames = nullptr;  // Don't forget to free or store hDevNames.
-    pd.hDC = nullptr;
-    pd.Flags = PD_USEDEVMODECOPIES | PD_RETURNDC | PD_PRINTSETUP |
-               PD_NOSELECTION | PD_NOPAGENUMS;
-    pd.nCopies = 1;
-    pd.nFromPage = 0xFFFF;
-    pd.nToPage = 0xFFFF;
-    pd.nMinPage = 1;
-    pd.nMaxPage = 0xFFFF;
+      auto r = PrintDlg(&pd);
 
-    auto r = PrintDlg(&pd);
+      if (r != 1) {
+        printing->onCompleted(this, false, "");
+        DeleteDC(hDC);
+        GlobalFree(hDevNames);
+        GlobalFree(hDevMode);
+        return true;
+      }
 
-    if (r != 1) {
-      printing->onCompleted(this, false, "");
-      DeleteDC(hDC);
-      GlobalFree(hDevNames);
-      ClosePrinter(hDevMode);
-      return true;
+      hDC = pd.hDC;
+      hDevMode = pd.hDevMode;
+      hDevNames = pd.hDevNames;
     }
-
-    hDC = pd.hDC;
-    hDevMode = pd.hDevMode;
-    hDevNames = pd.hDevNames;
-
   } else {
     hDC = CreateDC(TEXT("WINSPOOL"), fromUtf8(printer).c_str(), nullptr, dm);
     if (!hDC) {
@@ -171,7 +204,7 @@ bool PrintJob::printPdf(const std::string& name,
   auto marginBottom = pageHeight - printableHeight - marginTop;
 
   printing->onLayout(this, pageWidth, pageHeight, marginLeft, marginTop,
-                     marginRight, marginBottom);
+                      marginRight, marginBottom);
   return true;
 }
 
@@ -198,7 +231,7 @@ std::vector<Printer> PrintJob::listPrinters() {
   }
 
   auto result = EnumPrinters(flags, nullptr, 2, (LPBYTE)buffer, needed, &needed,
-                             &returned);
+                               &returned);
 
   if (result == 0) {
     free(buffer);
@@ -280,7 +313,7 @@ void PrintJob::writeJob(std::vector<uint8_t> data) {
 
   DeleteDC(hDC);
   GlobalFree(hDevNames);
-  ClosePrinter(hDevMode);
+  GlobalFree(hDevMode);
 
   printing->onCompleted(this, true, "");
 }
@@ -321,8 +354,8 @@ bool PrintJob::sharePdf(std::vector<uint8_t> data, const std::string& name) {
 void PrintJob::pickPrinter(void* result) {}
 
 void PrintJob::rasterPdf(std::vector<uint8_t> data,
-                         std::vector<int> pages,
-                         double scale) {
+                          std::vector<int> pages,
+                          double scale) {
   FPDF_LIBRARY_CONFIG config;
   config.version = 2;
   config.m_pUserFontPaths = nullptr;
@@ -383,7 +416,7 @@ void PrintJob::rasterPdf(std::vector<uint8_t> data,
     }
 
     printing->onPageRasterized(std::vector<uint8_t>{p, p + l}, bWidth, bHeight,
-                               this);
+                                this);
 
     FPDFBitmap_Destroy(bitmap);
     FPDF_ClosePage(page);
@@ -399,7 +432,7 @@ void PrintJob::rasterPdf(std::vector<uint8_t> data,
 std::map<std::string, bool> PrintJob::printingInfo() {
   return std::map<std::string, bool>{
       {"directPrint", true},     {"dynamicLayout", true}, {"canPrint", true},
-      {"canListPrinters", true}, {"canShare", true},      {"canRaster", true},
+      {"canListPrinters", true}, {"canShare", true},       {"canRaster", true},
   };
 }
 

--- a/printing/windows/print_job.cpp
+++ b/printing/windows/print_job.cpp
@@ -78,7 +78,7 @@ bool PrintJob::printPdf(const std::string& name,
                         double width,
                         double height,
                         bool usePrinterSettings,
-                        bool useModernDialog) {
+                        bool windowsModernDialog) {
   
   documentName = name;
 
@@ -113,7 +113,7 @@ bool PrintJob::printPdf(const std::string& name,
   }
 
   if (printer.empty()) {
-    if (useModernDialog) {
+    if (windowsModernDialog) {
       // --- MODERN OPTION (PrintDlgEx) ---
       PRINTDLGEX pdx = {0};
       pdx.lStructSize = sizeof(PRINTDLGEX);

--- a/printing/windows/print_job.cpp
+++ b/printing/windows/print_job.cpp
@@ -79,7 +79,7 @@ bool PrintJob::printPdf(const std::string& name,
                         double height,
                         bool usePrinterSettings,
                         bool windowsModernDialog) {
-  
+
   documentName = name;
 
   std::size_t dmSize = sizeof(DEVMODE);
@@ -122,15 +122,15 @@ bool PrintJob::printPdf(const std::string& name,
       dm = nullptr; // dialog takes ownership; may replace with new alloc
       pdx.hDevNames = nullptr;
       pdx.hDC = nullptr;
-      
+
       // Flags: Use PD_RETURNDC to get the context we need for PDFium
       pdx.Flags = PD_RETURNDC | PD_USEDEVMODECOPIESANDCOLLATE | PD_NOPAGENUMS | PD_NOSELECTION;
-      
+
       pdx.nStartPage = START_PAGE_GENERAL;
       pdx.nMaxPageRanges = 1;
       PRINTPAGERANGE ranges[1] = {{1, 1}}; // Required structure for PDX
       pdx.lpPageRanges = ranges;
-      
+
       HRESULT hr = PrintDlgEx(&pdx);
 
       // Check if the user actually clicked "Print"
@@ -168,9 +168,9 @@ bool PrintJob::printPdf(const std::string& name,
 
       if (r != 1) {
         printing->onCompleted(this, false, "");
-        DeleteDC(hDC);
-        GlobalFree(hDevNames);
-        GlobalFree(hDevMode);
+        if (pd.hDC) DeleteDC(pd.hDC);
+        if (pd.hDevNames) GlobalFree(pd.hDevNames);
+        if (pd.hDevMode) GlobalFree(pd.hDevMode);
         return true;
       }
 
@@ -268,16 +268,8 @@ void PrintJob::writeJob(std::vector<uint8_t> data) {
 
   auto r = StartDoc(hDC, &docInfo);
 
-  FPDF_LIBRARY_CONFIG config;
-  config.version = 2;
-  config.m_pUserFontPaths = nullptr;
-  config.m_pIsolate = nullptr;
-  config.m_v8EmbedderSlot = 0;
-  FPDF_InitLibraryWithConfig(&config);
-
   auto doc = FPDF_LoadMemDocument64(data.data(), data.size(), nullptr);
   if (!doc) {
-    FPDF_DestroyLibrary();
     return;
   }
 
@@ -307,7 +299,6 @@ void PrintJob::writeJob(std::vector<uint8_t> data) {
   }
 
   FPDF_CloseDocument(doc);
-  FPDF_DestroyLibrary();
 
   EndDoc(hDC);
 
@@ -356,16 +347,8 @@ void PrintJob::pickPrinter(void* result) {}
 void PrintJob::rasterPdf(std::vector<uint8_t> data,
                           std::vector<int> pages,
                           double scale) {
-  FPDF_LIBRARY_CONFIG config;
-  config.version = 2;
-  config.m_pUserFontPaths = nullptr;
-  config.m_pIsolate = nullptr;
-  config.m_v8EmbedderSlot = 0;
-  FPDF_InitLibraryWithConfig(&config);
-
   auto doc = FPDF_LoadMemDocument64(data.data(), data.size(), nullptr);
   if (!doc) {
-    FPDF_DestroyLibrary();
     printing->onPageRasterEnd(this, "Cannot raster a malformed PDF file");
     return;
   }
@@ -423,8 +406,6 @@ void PrintJob::rasterPdf(std::vector<uint8_t> data,
   }
 
   FPDF_CloseDocument(doc);
-
-  FPDF_DestroyLibrary();
 
   printing->onPageRasterEnd(this, "");
 }

--- a/printing/windows/print_job.h
+++ b/printing/windows/print_job.h
@@ -76,7 +76,7 @@ class PrintJob {
                 double width,
                 double height,
                 bool usePrinterSettings,
-                bool useModernDialog);
+                bool windowsModernDialog);
 
   void writeJob(std::vector<uint8_t> data);
 

--- a/printing/windows/print_job.h
+++ b/printing/windows/print_job.h
@@ -75,7 +75,8 @@ class PrintJob {
                 std::string printer,
                 double width,
                 double height,
-                bool usePrinterSettings);
+                bool usePrinterSettings,
+                bool useModernDialog);
 
   void writeJob(std::vector<uint8_t> data);
 

--- a/printing/windows/printing.cpp
+++ b/printing/windows/printing.cpp
@@ -17,14 +17,24 @@
 #include "printing.h"
 
 #include "print_job.h"
+#include <fpdfview.h>
 
 namespace nfet {
 
 extern std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel;
 
-Printing::Printing() {}
+Printing::Printing() {
+  FPDF_LIBRARY_CONFIG config;
+  config.version = 2;
+  config.m_pUserFontPaths = nullptr;
+  config.m_pIsolate = nullptr;
+  config.m_v8EmbedderSlot = 0;
+  FPDF_InitLibraryWithConfig(&config);
+}
 
-Printing::~Printing() {}
+Printing::~Printing() {
+  FPDF_DestroyLibrary();
+}
 
 void Printing::onPageRasterized(std::vector<uint8_t> data,
                                 int width,

--- a/printing/windows/printing_plugin.cpp
+++ b/printing/windows/printing_plugin.cpp
@@ -81,16 +81,16 @@ class PrintingPlugin : public flutter::Plugin {
       auto usePrinterSettings = std::get<bool>(
           arguments->find(flutter::EncodableValue("usePrinterSettings"))
               ->second);
-      bool useModernDialog = false;
-      auto it = arguments->find(flutter::EncodableValue("useModernDialog"));
+      bool windowsModernDialog = false;
+      auto it = arguments->find(flutter::EncodableValue("windowsModernDialog"));
       if (it != arguments->end() && !it->second.IsNull()) {
-        useModernDialog = std::get<bool>(it->second);
+        windowsModernDialog = std::get<bool>(it->second);
       }
       auto vJob = arguments->find(flutter::EncodableValue("job"));
       auto jobNum = vJob != arguments->end() ? std::get<int>(vJob->second) : -1;
       auto job = new PrintJob{&printing, jobNum};
       auto res =
-          job->printPdf(name, printer, width, height, usePrinterSettings, useModernDialog);
+          job->printPdf(name, printer, width, height, usePrinterSettings, windowsModernDialog);
       if (!res) {
         delete job;
       }

--- a/printing/windows/printing_plugin.cpp
+++ b/printing/windows/printing_plugin.cpp
@@ -81,11 +81,16 @@ class PrintingPlugin : public flutter::Plugin {
       auto usePrinterSettings = std::get<bool>(
           arguments->find(flutter::EncodableValue("usePrinterSettings"))
               ->second);
+      bool useModernDialog = false;
+      auto it = arguments->find(flutter::EncodableValue("useModernDialog"));
+      if (it != arguments->end() && !it->second.IsNull()) {
+        useModernDialog = std::get<bool>(it->second);
+      }
       auto vJob = arguments->find(flutter::EncodableValue("job"));
       auto jobNum = vJob != arguments->end() ? std::get<int>(vJob->second) : -1;
       auto job = new PrintJob{&printing, jobNum};
       auto res =
-          job->printPdf(name, printer, width, height, usePrinterSettings);
+          job->printPdf(name, printer, width, height, usePrinterSettings, useModernDialog);
       if (!res) {
         delete job;
       }

--- a/widget_wrapper/pubspec.yaml
+++ b/widget_wrapper/pubspec.yaml
@@ -13,7 +13,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  pdf: ^3.10.0
+  pdf:
+    git:
+      url: https://github.com/ptech/dart_pdf.git
+      ref: v3.11.3-ptech # Fix thread issues on iOS and MacOS printing plugin
+      path: pdf
 
 dependency_overrides:
   pdf:

--- a/widget_wrapper/pubspec.yaml
+++ b/widget_wrapper/pubspec.yaml
@@ -13,11 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  pdf:
-    git:
-      url: https://github.com/ptech/dart_pdf.git
-      ref: v3.11.3-ptech # Fix thread issues on iOS and MacOS printing plugin
-      path: pdf
+  pdf: ^3.12.0
 
 dependency_overrides:
   pdf:


### PR DESCRIPTION
This PR proposes syncing the current fork branch (Dr-Usman:master) into upstream master.

Context:
- This branch includes prior fork updates and is currently ahead of upstream.
- It includes our Windows printing stability fix (post-print crash after Printing.layoutPdf).

Included upstream work already present in this fork:

1) PR #1921
Link: https://github.com/DavBfr/dart_pdf/pull/1921
Title: Fix threading issues in iOS and macOS printing plugin
Summary:
- Resolves thread/deadlock issues reported across platforms (macOS/iOS deadlocks and Windows property-related instability noted in the PR context).
- Ensures printing logic is coordinated on the main thread with a runloop-driven approach so UI remains responsive while waiting for Dart PDF data.
- Includes handling to avoid duplicated .pdf extension behavior.

2) PR #1913
Link: https://github.com/DavBfr/dart_pdf/pull/1913
Title: Fixed deadlock on macOS & added filtering of redundant layout requests
Summary:
- Replaces semaphore-based blocking with RunLoop polling to avoid deadlocks on newer Flutter merged-thread runtimes.
- Adds timeout safety during PDF wait.
- Adds layout parameter caching to avoid redundant onLayout calls.
- Shares PrintJobs between plugin instances (multi-window safety) and uses randomized job ID start values.

Additional Windows fix included in this fork:
- Move PDFium init/destroy to plugin lifetime in printing/windows/printing.cpp.
- Remove per-job FPDF_DestroyLibrary() calls in printing/windows/print_job.cpp.
- Fix classic PrintDlg cancel cleanup to release dialog handles safely (pd.hDC, pd.hDevMode, pd.hDevNames).

Why:
- Prevents plugin-level PDFium teardown during app lifetime, which can crash other PDF viewers in host apps after printing on Windows.
- Improves printing stability and cross-window correctness.
