### PR TITLE
Created and applied `PdfException` over the pdf classes

### DIFF
--- a/pdf/lib/pdf.dart
+++ b/pdf/lib/pdf.dart
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export 'src/base/exceptions.dart';
 export 'src/pdf/color.dart';
 export 'src/pdf/colors.dart';
 export 'src/pdf/document.dart';

--- a/pdf/lib/src/base/exceptions.dart
+++ b/pdf/lib/src/base/exceptions.dart
@@ -1,0 +1,15 @@
+/// A base exception for all PDF related exceptions.
+class PdfException implements Exception {
+  const PdfException([this.message]);
+
+  final String? message;
+
+  @override
+  String toString() =>
+      message == null ? runtimeType.toString() : '$runtimeType: $message';
+}
+
+/// Exception thrown when generator populates more pages than `maxPages` of [MultiPage].
+class PdfTooBigPageException extends PdfException {
+  const PdfTooBigPageException([super.message]);
+}

--- a/pdf/lib/src/pdf/obj/function.dart
+++ b/pdf/lib/src/pdf/obj/function.dart
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import '../../base/exceptions.dart';
 import '../color.dart';
 import '../document.dart';
 import '../format/array.dart';
@@ -24,7 +25,7 @@ import 'object_stream.dart';
 
 abstract class PdfBaseFunction extends PdfObject<PdfDict> {
   PdfBaseFunction(PdfDocument pdfDocument)
-    : super(pdfDocument, params: PdfDict());
+      : super(pdfDocument, params: PdfDict());
 
   factory PdfBaseFunction.colorsAndStops(
     PdfDocument pdfDocument,
@@ -52,7 +53,7 @@ abstract class PdfBaseFunction extends PdfObject<PdfDict> {
     }
 
     if (_stops.length != _colors.length) {
-      throw Exception(
+      throw PdfException(
         'The number of colors in a gradient must match the number of stops',
       );
     }

--- a/pdf/lib/src/pdf/obj/type1_font.dart
+++ b/pdf/lib/src/pdf/obj/type1_font.dart
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import '../../base/exceptions.dart';
 import '../../priv.dart';
 import '../document.dart';
 import '../font/font_metrics.dart';
@@ -44,14 +45,14 @@ class PdfType1Font extends PdfFont {
     bool isFixedPitch = false,
     this.missingWidth = 0.600,
     this.widths = const <double>[],
-  }) : assert(() {
-         // ignore: avoid_print
-         print(
-           '$fontName has no Unicode support see https://github.com/DavBfr/dart_pdf/wiki/Fonts-Management',
-         );
-         return true;
-       }()),
-       super.create(pdfDocument, subtype: '/Type1') {
+  })  : assert(() {
+          // ignore: avoid_print
+          print(
+            '$fontName has no Unicode support see https://github.com/DavBfr/dart_pdf/wiki/Fonts-Management',
+          );
+          return true;
+        }()),
+        super.create(pdfDocument, subtype: '/Type1') {
     params['/BaseFont'] = PdfName('/$fontName');
     if (settings.version.index >= PdfVersion.pdf_1_5.index) {
       params['/FirstChar'] = const PdfNum(0);
@@ -108,7 +109,7 @@ class PdfType1Font extends PdfFont {
   @override
   PdfFontMetrics glyphMetrics(int charCode) {
     if (!isRuneSupported(charCode)) {
-      throw Exception(
+      throw PdfException(
         'Unable to display U+${charCode.toRadixString(16)} with $fontName',
       );
     }

--- a/pdf/lib/src/svg/parser.dart
+++ b/pdf/lib/src/svg/parser.dart
@@ -17,6 +17,7 @@
 import 'package:xml/xml.dart';
 
 import '../../pdf.dart';
+import '../base/exceptions.dart';
 import 'brush.dart';
 
 class SvgParser {
@@ -35,7 +36,7 @@ class SvgParser {
         : splitDoubles(vbattr);
 
     if (vb.isEmpty || vb.length > 4) {
-      throw Exception('viewBox must contain 1..4 parameters');
+      throw PdfException('ViewBox must contain 1..4 parameters');
     }
 
     final fvb = [...List<double>.filled(4 - vb.length, 0), ...vb];
@@ -70,8 +71,8 @@ class SvgParser {
   XmlElement? findById(String id) {
     try {
       return root.descendants.whereType<XmlElement>().firstWhere(
-        (e) => e.getAttribute('id') == id,
-      );
+            (e) => e.getAttribute('id') == id,
+          );
     } on StateError {
       return null;
     }
@@ -194,7 +195,7 @@ class SvgNumeric {
       case SvgUnit.direct:
         return value / 255.0;
       default:
-        throw Exception('Invalid color value $value ($unit)');
+        throw PdfException('Invalid color value $value ($unit)');
     }
   }
 

--- a/pdf/lib/src/svg/path.dart
+++ b/pdf/lib/src/svg/path.dart
@@ -19,6 +19,7 @@ import 'dart:math' as math;
 import 'package:xml/xml.dart';
 
 import '../../pdf.dart';
+import '../base/exceptions.dart';
 import 'brush.dart';
 import 'clip_path.dart';
 import 'operation.dart';
@@ -42,7 +43,7 @@ class SvgPath extends SvgOperation {
   ) {
     final d = element.getAttribute('d');
     if (d == null) {
-      throw Exception('Path element must contain "d" attribute');
+      throw PdfException('Path element must contain "d" attribute');
     }
 
     final _brush = SvgBrush.fromXml(element, brush, painter);
@@ -63,10 +64,16 @@ class SvgPath extends SvgOperation {
   ) {
     final _brush = SvgBrush.fromXml(element, brush, painter);
 
-    final x = SvgParser.getNumeric(element, 'x', _brush, defaultValue: 0)!.sizeValue;
-    final y = SvgParser.getNumeric(element, 'y', _brush, defaultValue: 0)!.sizeValue;
-    final width = SvgParser.getNumeric(element, 'width', _brush, defaultValue: 0)!.sizeValue;
-    final height = SvgParser.getNumeric(element, 'height', _brush, defaultValue: 0)!.sizeValue;
+    final x =
+        SvgParser.getNumeric(element, 'x', _brush, defaultValue: 0)!.sizeValue;
+    final y =
+        SvgParser.getNumeric(element, 'y', _brush, defaultValue: 0)!.sizeValue;
+    final width =
+        SvgParser.getNumeric(element, 'width', _brush, defaultValue: 0)!
+            .sizeValue;
+    final height =
+        SvgParser.getNumeric(element, 'height', _brush, defaultValue: 0)!
+            .sizeValue;
 
     var rx = SvgParser.getNumeric(element, 'rx', _brush)?.sizeValue;
     var ry = SvgParser.getNumeric(element, 'ry', _brush)?.sizeValue;
@@ -75,9 +82,8 @@ class SvgPath extends SvgOperation {
     rx ??= ry;
     final topRight = rx != 0 || ry != 0 ? 'a $rx $ry 0 0 1 $rx $ry' : '';
     final bottomRight = rx != 0 || ry != 0 ? 'a $rx $ry 0 0 1 ${-rx} $ry' : '';
-    final bottomLeft = rx != 0 || ry != 0
-        ? 'a $rx $ry 0 0 1 ${-rx} ${-ry}'
-        : '';
+    final bottomLeft =
+        rx != 0 || ry != 0 ? 'a $rx $ry 0 0 1 ${-rx} ${-ry}' : '';
     final topLeft = rx != 0 || ry != 0 ? 'a $rx $ry 0 0 1 $rx ${-ry}' : '';
     final d =
         'M${x + rx} ${y}h${width - rx * 2}${topRight}v${height - ry * 2}${bottomRight}h${-(width - rx * 2)}${bottomLeft}v${-(height - ry * 2)}${topLeft}z';
@@ -98,9 +104,12 @@ class SvgPath extends SvgOperation {
   ) {
     final _brush = SvgBrush.fromXml(element, brush, painter);
 
-    final cx = SvgParser.getNumeric(element, 'cx', _brush, defaultValue: 0)!.sizeValue;
-    final cy = SvgParser.getNumeric(element, 'cy', _brush, defaultValue: 0)!.sizeValue;
-    final r = SvgParser.getNumeric(element, 'r', _brush, defaultValue: 0)!.sizeValue;
+    final cx =
+        SvgParser.getNumeric(element, 'cx', _brush, defaultValue: 0)!.sizeValue;
+    final cy =
+        SvgParser.getNumeric(element, 'cy', _brush, defaultValue: 0)!.sizeValue;
+    final r =
+        SvgParser.getNumeric(element, 'r', _brush, defaultValue: 0)!.sizeValue;
     final d =
         'M${cx - r},${cy}A$r,$r 0,0,0 ${cx + r},${cy}A$r,$r 0,0,0 ${cx - r},${cy}z';
 
@@ -120,10 +129,14 @@ class SvgPath extends SvgOperation {
   ) {
     final _brush = SvgBrush.fromXml(element, brush, painter);
 
-    final cx = SvgParser.getNumeric(element, 'cx', _brush, defaultValue: 0)!.sizeValue;
-    final cy = SvgParser.getNumeric(element, 'cy', _brush, defaultValue: 0)!.sizeValue;
-    final rx = SvgParser.getNumeric(element, 'rx', _brush, defaultValue: 0)!.sizeValue;
-    final ry = SvgParser.getNumeric(element, 'ry', _brush, defaultValue: 0)!.sizeValue;
+    final cx =
+        SvgParser.getNumeric(element, 'cx', _brush, defaultValue: 0)!.sizeValue;
+    final cy =
+        SvgParser.getNumeric(element, 'cy', _brush, defaultValue: 0)!.sizeValue;
+    final rx =
+        SvgParser.getNumeric(element, 'rx', _brush, defaultValue: 0)!.sizeValue;
+    final ry =
+        SvgParser.getNumeric(element, 'ry', _brush, defaultValue: 0)!.sizeValue;
     final d =
         'M${cx - rx},${cy}A$rx,$ry 0,0,0 ${cx + rx},${cy}A$rx,$ry 0,0,0 ${cx - rx},${cy}z';
 
@@ -180,10 +193,14 @@ class SvgPath extends SvgOperation {
   ) {
     final _brush = SvgBrush.fromXml(element, brush, painter);
 
-    final x1 = SvgParser.getNumeric(element, 'x1', _brush, defaultValue: 0)!.sizeValue;
-    final y1 = SvgParser.getNumeric(element, 'y1', _brush, defaultValue: 0)!.sizeValue;
-    final x2 = SvgParser.getNumeric(element, 'x2', _brush, defaultValue: 0)!.sizeValue;
-    final y2 = SvgParser.getNumeric(element, 'y2', _brush, defaultValue: 0)!.sizeValue;
+    final x1 =
+        SvgParser.getNumeric(element, 'x1', _brush, defaultValue: 0)!.sizeValue;
+    final y1 =
+        SvgParser.getNumeric(element, 'y1', _brush, defaultValue: 0)!.sizeValue;
+    final x2 =
+        SvgParser.getNumeric(element, 'x2', _brush, defaultValue: 0)!.sizeValue;
+    final y2 =
+        SvgParser.getNumeric(element, 'y2', _brush, defaultValue: 0)!.sizeValue;
     final d = 'M$x1 $y1 $x2 $y2';
 
     return SvgPath(

--- a/pdf/lib/src/widgets/flex.dart
+++ b/pdf/lib/src/widgets/flex.dart
@@ -20,6 +20,7 @@ import 'package:vector_math/vector_math_64.dart';
 
 import '../../pdf.dart';
 import '../../widgets.dart';
+import '../base/exceptions.dart';
 
 enum FlexFit { tight, loose }
 
@@ -86,9 +87,9 @@ class Flex extends MultiChildWidget with SpanningWidget {
   double _getIntrinsicSize({
     Axis? sizingDirection,
     double?
-    extent, // the extent in the direction that isn't the sizing direction
+        extent, // the extent in the direction that isn't the sizing direction
     _ChildSizingFunction?
-    childSize, // a method to find the size in the sizing direction
+        childSize, // a method to find the size in the sizing direction
   }) {
     if (direction == sizingDirection) {
       // INTRINSIC MAIN SIZE
@@ -240,7 +241,7 @@ class Flex extends MultiChildWidget with SpanningWidget {
           final dimension = direction == Axis.horizontal ? 'width' : 'height';
           if (!canFlex &&
               (mainAxisSize == MainAxisSize.max || fit == FlexFit.tight)) {
-            throw Exception(
+            throw PdfException(
               'Flex children have non-zero flex but incoming $dimension constraints are unbounded.',
             );
           } else {
@@ -299,9 +300,8 @@ class Flex extends MultiChildWidget with SpanningWidget {
     );
     var allocatedFlexSpace = 0.0;
     if (totalFlex > 0) {
-      final spacePerFlex = canFlex && totalFlex > 0
-          ? (freeSpace / totalFlex)
-          : double.nan;
+      final spacePerFlex =
+          canFlex && totalFlex > 0 ? (freeSpace / totalFlex) : double.nan;
 
       for (final child in children) {
         final flex = child is Flexible ? child.flex : 0;
@@ -309,8 +309,8 @@ class Flex extends MultiChildWidget with SpanningWidget {
         if (flex > 0) {
           final maxChildExtent = canFlex
               ? (child == lastFlexChild
-                    ? (freeSpace - allocatedFlexSpace)
-                    : spacePerFlex * flex)
+                  ? (freeSpace - allocatedFlexSpace)
+                  : spacePerFlex * flex)
               : double.infinity;
           double? minChildExtent;
           switch (fit) {
@@ -418,26 +418,23 @@ class Flex extends MultiChildWidget with SpanningWidget {
         break;
       case MainAxisAlignment.spaceBetween:
         leadingSpace = 0.0;
-        betweenSpace = totalChildren > 1
-            ? remainingSpace / (totalChildren - 1)
-            : 0.0;
+        betweenSpace =
+            totalChildren > 1 ? remainingSpace / (totalChildren - 1) : 0.0;
         break;
       case MainAxisAlignment.spaceAround:
         betweenSpace = totalChildren > 0 ? remainingSpace / totalChildren : 0.0;
         leadingSpace = betweenSpace / 2.0;
         break;
       case MainAxisAlignment.spaceEvenly:
-        betweenSpace = totalChildren > 0
-            ? remainingSpace / (totalChildren + 1)
-            : 0.0;
+        betweenSpace =
+            totalChildren > 0 ? remainingSpace / (totalChildren + 1) : 0.0;
         leadingSpace = betweenSpace;
         break;
     }
 
     // Position elements
-    var childMainPosition = flipMainAxis
-        ? actualSize - leadingSpace
-        : leadingSpace;
+    var childMainPosition =
+        flipMainAxis ? actualSize - leadingSpace : leadingSpace;
 
     for (var child in children.sublist(
       _context.firstChild,
@@ -447,8 +444,7 @@ class Flex extends MultiChildWidget with SpanningWidget {
       switch (crossAxisAlignment) {
         case CrossAxisAlignment.start:
         case CrossAxisAlignment.end:
-          childCrossPosition =
-              _startIsTopLeft(
+          childCrossPosition = _startIsTopLeft(
                     flipAxis(direction),
                     textDirection,
                     verticalDirection,
@@ -575,13 +571,13 @@ class Row extends Flex {
     VerticalDirection verticalDirection = VerticalDirection.down,
     List<Widget> children = const <Widget>[],
   }) : super(
-         children: children,
-         direction: Axis.horizontal,
-         mainAxisAlignment: mainAxisAlignment,
-         mainAxisSize: mainAxisSize,
-         crossAxisAlignment: crossAxisAlignment,
-         verticalDirection: verticalDirection,
-       );
+          children: children,
+          direction: Axis.horizontal,
+          mainAxisAlignment: mainAxisAlignment,
+          mainAxisSize: mainAxisSize,
+          crossAxisAlignment: crossAxisAlignment,
+          verticalDirection: verticalDirection,
+        );
 }
 
 class Column extends Flex {
@@ -592,19 +588,19 @@ class Column extends Flex {
     VerticalDirection verticalDirection = VerticalDirection.down,
     List<Widget> children = const <Widget>[],
   }) : super(
-         children: children,
-         direction: Axis.vertical,
-         mainAxisAlignment: mainAxisAlignment,
-         mainAxisSize: mainAxisSize,
-         crossAxisAlignment: crossAxisAlignment,
-         verticalDirection: verticalDirection,
-       );
+          children: children,
+          direction: Axis.vertical,
+          mainAxisAlignment: mainAxisAlignment,
+          mainAxisSize: mainAxisSize,
+          crossAxisAlignment: crossAxisAlignment,
+          verticalDirection: verticalDirection,
+        );
 }
 
 /// A widget that controls how a child of a [Row], [Column], or [Flex] flexes.
 class Flexible extends SingleChildWidget {
   Flexible({this.flex = 1, this.fit = FlexFit.loose, required Widget child})
-    : super(child: child);
+      : super(child: child);
 
   /// The flex factor to use for this child
   final int flex;
@@ -621,15 +617,15 @@ class Flexible extends SingleChildWidget {
 
 class Expanded extends Flexible {
   Expanded({int flex = 1, FlexFit fit = FlexFit.tight, required Widget child})
-    : super(child: child, flex: flex, fit: fit);
+      : super(child: child, flex: flex, fit: fit);
 }
 
 /// Spacer creates an adjustable, empty spacer that can be used to tune the
 /// spacing between widgets in a [Flex] container, like [Row] or [Column].
 class Spacer extends Flexible {
   Spacer({int flex = 1})
-    : assert(flex > 0),
-      super(flex: flex, fit: FlexFit.tight, child: SizedBox.shrink());
+      : assert(flex > 0),
+        super(flex: flex, fit: FlexFit.tight, child: SizedBox.shrink());
 }
 
 typedef IndexedWidgetBuilder = Widget Function(Context context, int index);
@@ -641,10 +637,10 @@ class ListView extends StatelessWidget {
     this.spacing = 0,
     this.padding,
     List<Widget> this.children = const <Widget>[],
-  }) : itemBuilder = null,
-       separatorBuilder = null,
-       itemCount = children.length,
-       super();
+  })  : itemBuilder = null,
+        separatorBuilder = null,
+        itemCount = children.length,
+        super();
 
   ListView.builder({
     this.direction = Axis.vertical,
@@ -653,9 +649,9 @@ class ListView extends StatelessWidget {
     this.padding,
     required this.itemBuilder,
     required this.itemCount,
-  }) : children = null,
-       separatorBuilder = null,
-       super();
+  })  : children = null,
+        separatorBuilder = null,
+        super();
 
   ListView.separated({
     this.direction = Axis.vertical,
@@ -664,9 +660,9 @@ class ListView extends StatelessWidget {
     required this.itemBuilder,
     required this.separatorBuilder,
     required this.itemCount,
-  }) : children = null,
-       spacing = null,
-       super();
+  })  : children = null,
+        spacing = null,
+        super();
 
   final Axis direction;
   final EdgeInsetsGeometry? padding;
@@ -685,8 +681,8 @@ class ListView extends StatelessWidget {
     return spacing == null
         ? separatorBuilder!(context, index)
         : direction == Axis.vertical
-        ? SizedBox(height: spacing)
-        : SizedBox(width: spacing);
+            ? SizedBox(height: spacing)
+            : SizedBox(width: spacing);
   }
 
   @override

--- a/pdf/lib/src/widgets/grid_view.dart
+++ b/pdf/lib/src/widgets/grid_view.dart
@@ -19,6 +19,7 @@ import 'dart:math' as math;
 import 'package:vector_math/vector_math_64.dart';
 
 import '../../pdf.dart';
+import '../base/exceptions.dart';
 import 'flex.dart';
 import 'geometry.dart';
 import 'multi_page.dart';
@@ -112,8 +113,7 @@ class GridView extends MultiChildWidget with SpanningWidget {
       _mainAxisCount =
           ((children.length - _context.firstChild) / crossAxisCount).ceil();
 
-      _context.childCrossAxis =
-          crossAxisExtent / crossAxisCount -
+      _context.childCrossAxis = crossAxisExtent / crossAxisCount -
           (crossAxisSpacing * (crossAxisCount - 1) / crossAxisCount);
 
       _context.childMainAxis = math.min(
@@ -123,15 +123,14 @@ class GridView extends MultiChildWidget with SpanningWidget {
       );
 
       if (_context.childCrossAxis!.isInfinite) {
-        throw Exception(
+        throw PdfException(
           'Unable to calculate child height as the height constraint is infinite.',
         );
       }
     } else {
-      _mainAxisCount =
-          ((mainAxisExtent + mainAxisSpacing) /
-                  (mainAxisSpacing + _context.childMainAxis!))
-              .floor();
+      _mainAxisCount = ((mainAxisExtent + mainAxisSpacing) /
+              (mainAxisSpacing + _context.childMainAxis!))
+          .floor();
 
       if (_mainAxisCount! < 0) {
         // Not enough space to put one line, try to ask for more space.
@@ -141,10 +140,10 @@ class GridView extends MultiChildWidget with SpanningWidget {
 
     final totalMain =
         (_context.childMainAxis! + mainAxisSpacing) * _mainAxisCount! -
-        mainAxisSpacing;
+            mainAxisSpacing;
     final totalCross =
         (_context.childCrossAxis! + crossAxisSpacing) * crossAxisCount -
-        crossAxisSpacing;
+            crossAxisSpacing;
 
     final startX = resolvedPadding.left;
     const startY = 0.0;
@@ -191,7 +190,7 @@ class GridView extends MultiChildWidget with SpanningWidget {
               isRtl
                   ? (_context.childCrossAxis! + child.box!.width - crossAxis)
                   : (_context.childCrossAxis! - child.box!.width) / 2.0 +
-                        crossAxis,
+                      crossAxis,
               totalMain +
                   resolvedPadding.bottom -
                   (_context.childMainAxis! - child.box!.height) / 2.0 -
@@ -208,7 +207,7 @@ class GridView extends MultiChildWidget with SpanningWidget {
               isRtl
                   ? totalMain - (child.box!.width + mainAxis)
                   : (_context.childMainAxis! - child.box!.width) / 2.0 +
-                        mainAxis,
+                      mainAxis,
               totalCross +
                   resolvedPadding.bottom -
                   (_context.childCrossAxis! - child.box!.height) / 2.0 -

--- a/pdf/lib/src/widgets/image_provider.dart
+++ b/pdf/lib/src/widgets/image_provider.dart
@@ -19,6 +19,7 @@ import 'dart:typed_data';
 import 'package:image/image.dart' as im;
 
 import '../../pdf.dart';
+import '../base/exceptions.dart';
 import 'widget.dart';
 
 /// Identifies an image without committing to the precise final asset
@@ -76,7 +77,7 @@ abstract class ImageProvider {
 
 class ImageProxy extends ImageProvider {
   ImageProxy(this._image, {double? dpi})
-    : super(_image.width, _image.height, _image.orientation, dpi);
+      : super(_image.width, _image.height, _image.orientation, dpi);
 
   /// The proxy image
   final PdfImage _image;
@@ -93,7 +94,8 @@ class MemoryImage extends ImageProvider {
   }) {
     final decoder = im.findDecoderForData(bytes);
     if (decoder == null) {
-      throw Exception('Unable to guess the image type ${bytes.length} bytes');
+      throw PdfException(
+          'Unable to guess the image type ${bytes.length} bytes');
     }
 
     if (decoder is im.JpegDecoder) {
@@ -111,7 +113,7 @@ class MemoryImage extends ImageProvider {
     final info = decoder.startDecode(bytes);
 
     if (info == null) {
-      throw Exception('Unable decode the image');
+      throw PdfException('Unable decode the image');
     }
 
     return MemoryImage._(
@@ -143,7 +145,7 @@ class MemoryImage extends ImageProvider {
     final image = im.decodeImage(bytes);
 
     if (image == null) {
-      throw Exception('Unable decode the image');
+      throw PdfException('Unable decode the image');
     }
 
     final resized = im.copyResize(image, width: width);
@@ -153,12 +155,12 @@ class MemoryImage extends ImageProvider {
 
 class ImageImage extends ImageProvider {
   ImageImage(this._image, {double? dpi, PdfImageOrientation? orientation})
-    : super(
-        _image.width,
-        _image.height,
-        orientation ?? PdfImageOrientation.topLeft,
-        dpi,
-      );
+      : super(
+          _image.width,
+          _image.height,
+          orientation ?? PdfImageOrientation.topLeft,
+          dpi,
+        );
 
   /// The image data
   final im.Image _image;
@@ -182,8 +184,8 @@ class RawImage extends ImageImage {
     PdfImageOrientation? orientation,
     double? dpi,
   }) : super(
-         PdfRasterBase(width, height, true, bytes).asImage(),
-         orientation: orientation,
-         dpi: dpi,
-       );
+          PdfRasterBase(width, height, true, bytes).asImage(),
+          orientation: orientation,
+          dpi: dpi,
+        );
 }

--- a/pdf/lib/src/widgets/multi_page.dart
+++ b/pdf/lib/src/widgets/multi_page.dart
@@ -20,6 +20,7 @@ import 'package:meta/meta.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import '../../pdf.dart';
+import '../base/exceptions.dart';
 import 'basic.dart';
 import 'document.dart';
 import 'flex.dart';
@@ -185,17 +186,17 @@ class MultiPage extends Page {
     PageOrientation? orientation,
     EdgeInsetsGeometry? margin,
     TextDirection? textDirection,
-  }) : _buildList = build,
-       assert(maxPages > 0),
-       super(
-         pageTheme: pageTheme,
-         pageFormat: pageFormat,
-         build: (_) => SizedBox(),
-         margin: margin,
-         theme: theme,
-         orientation: orientation,
-         textDirection: textDirection,
-       );
+  })  : _buildList = build,
+        assert(maxPages > 0),
+        super(
+          pageTheme: pageTheme,
+          pageFormat: pageFormat,
+          build: (_) => SizedBox(),
+          margin: margin,
+          theme: theme,
+          orientation: orientation,
+          textDirection: textDirection,
+        );
 
   final BuildListCallback _buildList;
 
@@ -254,9 +255,8 @@ class MultiPage extends Page {
     final _margin = resolvedMargin!;
     final _mustRotate = mustRotate;
     final pageHeight = _mustRotate ? pageFormat.width : pageFormat.height;
-    final pageHeightMargin = _mustRotate
-        ? _margin.horizontal
-        : _margin.vertical;
+    final pageHeightMargin =
+        _mustRotate ? _margin.horizontal : _margin.vertical;
     final constraints = BoxConstraints(
       maxWidth: _mustRotate
           ? (pageFormat.height - _margin.vertical)
@@ -277,12 +277,12 @@ class MultiPage extends Page {
     double? offsetStart;
     var _index = 0;
     var sameCount = 0;
-    final baseContext = Context(document: document.document)
-        .inheritFromAll(<Inherited>[
-          calculatedTheme,
-          if (pageTheme.textDirection != null)
-            InheritedDirectionality(pageTheme.textDirection),
-        ]);
+    final baseContext =
+        Context(document: document.document).inheritFromAll(<Inherited>[
+      calculatedTheme,
+      if (pageTheme.textDirection != null)
+        InheritedDirectionality(pageTheme.textDirection),
+    ]);
     final children = _buildList(baseContext);
     WidgetContext? widgetContext;
 
@@ -292,8 +292,9 @@ class MultiPage extends Page {
       assert(() {
         // Detect too big widgets
         if (sameCount++ > maxPages) {
-          throw TooManyPagesException(
-            'This widget created more than $maxPages pages. This may be an issue in the widget or the document. See https://pub.dev/documentation/pdf/latest/widgets/MultiPage-class.html',
+          throw PdfTooBigPageException(
+            'This widget created more than $maxPages pages. This may be an issue in the widget or '
+            'the document. See https://pub.dev/documentation/pdf/latest/widgets/MultiPage-class.html',
           );
         }
         return true;
@@ -323,12 +324,10 @@ class MultiPage extends Page {
           return true;
         }());
 
-        offsetStart =
-            pageHeight -
+        offsetStart = pageHeight -
             (_mustRotate ? pageHeightMargin - _margin.bottom : _margin.top);
-        offsetEnd = _mustRotate
-            ? pageHeightMargin - _margin.left
-            : _margin.bottom;
+        offsetEnd =
+            _mustRotate ? pageHeightMargin - _margin.left : _margin.bottom;
 
         _pages.add(
           _MultiPageInstance(
@@ -382,7 +381,7 @@ class MultiPage extends Page {
 
         // Else we crash if the widget is too big and cannot be separated
         if (!canSpan) {
-          throw Exception(
+          throw PdfException(
             'Widget won\'t fit into the page as its height (${child.box!.height}) '
             'exceed a page height (${pageHeight - pageHeightMargin}). '
             'You probably need a SpanningWidget or use a single page layout',
@@ -425,9 +424,8 @@ class MultiPage extends Page {
         _MultiPageWidget(
           child: child,
           constraints: constraints,
-          widgetContext: child is SpanningWidget && canSpan
-              ? child.cloneContext()
-              : null,
+          widgetContext:
+              child is SpanningWidget && canSpan ? child.cloneContext() : null,
         ),
       );
 
@@ -443,19 +441,16 @@ class MultiPage extends Page {
     final _mustRotate = mustRotate;
     final pageHeight = _mustRotate ? pageFormat.width : pageFormat.height;
     final pageWidth = _mustRotate ? pageFormat.height : pageFormat.width;
-    final pageHeightMargin = _mustRotate
-        ? _margin.horizontal
-        : _margin.vertical;
+    final pageHeightMargin =
+        _mustRotate ? _margin.horizontal : _margin.vertical;
     final pageWidthMargin = _mustRotate ? _margin.vertical : _margin.horizontal;
     final availableWidth = pageWidth - pageWidthMargin;
     final isRTL = pageTheme.textDirection == TextDirection.rtl;
     for (final page in _pages) {
-      var offsetStart =
-          pageHeight -
+      var offsetStart = pageHeight -
           (_mustRotate ? pageHeightMargin - _margin.bottom : _margin.top);
-      var offsetEnd = _mustRotate
-          ? pageHeightMargin - _margin.left
-          : _margin.bottom;
+      var offsetEnd =
+          _mustRotate ? pageHeightMargin - _margin.left : _margin.bottom;
 
       if (pageTheme.buildBackground != null) {
         final child = pageTheme.buildBackground!(page.context);
@@ -562,18 +557,16 @@ class MultiPage extends Page {
             break;
           case MainAxisAlignment.spaceBetween:
             leadingSpace = 0.0;
-            betweenSpace = totalChildren > 1
-                ? freeSpace / (totalChildren - 1)
-                : 0.0;
+            betweenSpace =
+                totalChildren > 1 ? freeSpace / (totalChildren - 1) : 0.0;
             break;
           case MainAxisAlignment.spaceAround:
             betweenSpace = totalChildren > 0 ? freeSpace / totalChildren : 0.0;
             leadingSpace = betweenSpace / 2.0;
             break;
           case MainAxisAlignment.spaceEvenly:
-            betweenSpace = totalChildren > 0
-                ? freeSpace / (totalChildren + 1)
-                : 0.0;
+            betweenSpace =
+                totalChildren > 0 ? freeSpace / (totalChildren + 1) : 0.0;
             leadingSpace = betweenSpace;
             break;
         }
@@ -674,11 +667,4 @@ class MultiPage extends Page {
       }
     }
   }
-}
-
-/// Exception thrown when generator populates more pages than [maxPages].
-class TooManyPagesException implements Exception {
-  TooManyPagesException(this.message);
-
-  final String message;
 }

--- a/pdf/lib/src/widgets/partitions.dart
+++ b/pdf/lib/src/widgets/partitions.dart
@@ -19,6 +19,7 @@ import 'dart:math' as math;
 import 'package:vector_math/vector_math_64.dart';
 
 import '../../pdf.dart';
+import '../base/exceptions.dart';
 import 'flex.dart';
 import 'geometry.dart';
 import 'multi_page.dart';
@@ -26,7 +27,7 @@ import 'widget.dart';
 
 class Partition extends Widget with SpanningWidget {
   Partition({required this.child, this.width, int flex = 1})
-    : flex = width == null ? flex : 0;
+      : flex = width == null ? flex : 0;
 
   final double? width;
 
@@ -79,7 +80,7 @@ class Partition extends Widget with SpanningWidget {
 
 class PartitionsContext extends WidgetContext {
   PartitionsContext(int count)
-    : partitionContext = List<WidgetContext?>.filled(count, null);
+      : partitionContext = List<WidgetContext?>.filled(count, null);
 
   final List<WidgetContext?> partitionContext;
 
@@ -103,8 +104,8 @@ class PartitionsContext extends WidgetContext {
 
 class Partitions extends Widget with SpanningWidget {
   Partitions({required this.children, this.mainAxisSize = MainAxisSize.max})
-    : _context = PartitionsContext(children.length),
-      super();
+      : _context = PartitionsContext(children.length),
+        super();
 
   final List<Partition> children;
 
@@ -138,7 +139,7 @@ class Partitions extends Widget with SpanningWidget {
       if (child.flex > 0) {
         assert(() {
           if (!canFlex) {
-            throw Exception(
+            throw PdfException(
               'Partition children have non-zero flex but incoming width constraints are unbounded.',
             );
           } else {


### PR DESCRIPTION
I was need to check the raised exception in a `pdf` package and noticed that general `Exception` is used. It is a good approach to use specific exceptions for a specific case but now I just implemented "native" `PdfException` and one successor `PdfTooBigPageException` which substitutes the `TooManyPageException`.

Just for convenience of exception handling in PDF package in code.