### PR TITLE
fix(printing): load pdf.js via esm import to fix CVE-2024-4367 (4.2.67)

### DIFF
--- a/printing/CHANGELOG.md
+++ b/printing/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix CVE-2024-4367: load pdf.js via ESM import (pdf.js 4.2.67)
 - Fix lint issues
 - Add Swift Package Manager support
 

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -51,7 +51,7 @@ class PrintingPlugin extends PrintingPlatform {
 
   static const _pdfJsCdnPath = 'https://unpkg.com/pdfjs-dist';
 
-  static const _pdfJsVersion = '3.2.146';
+  static const _pdfJsVersion = '4.2.67';
 
   final _loading = Mutex();
 
@@ -70,30 +70,8 @@ class PrintingPlugin extends PrintingPlatform {
     await _loading.acquire();
 
     if (!_hasPdfJsLib) {
-      js.JSObject? amd;
-      js.JSObject? define;
-      js.JSObject? module;
-      js.JSObject? exports;
-      if (web.window.hasProperty('define'.toJS).toDart) {
-        // In dev, requireJs is loaded in. Disable it here.
-        define = web.window.getProperty('define'.toJS);
-        amd = define!.getProperty('amd'.toJS);
-        define.setProperty('amd'.toJS, false.toJS);
-      }
-
-      // Save Webpack values and make typeof module != object
-      if (web.window.hasProperty('exports'.toJS).toDart) {
-        exports = web.window.getProperty('exports'.toJS);
-      }
-      web.window.setProperty('exports'.toJS, 0.toJS);
-
-      if (web.window.hasProperty('module'.toJS).toDart) {
-        module = web.window.getProperty('module'.toJS);
-      }
-      web.window.setProperty('module'.toJS, 0.toJS);
-
       // Check if the source of PDF.js library is overridden via
-      // [dartPdfJsBaseUrl] JavaScript  variable.
+      // [dartPdfJsBaseUrl] JavaScript variable.
       if (web.window.hasProperty(_dartPdfJsBaseUrl.toJS).toDart) {
         _pdfJsUrlBase = web.window.getProperty(_dartPdfJsBaseUrl.toJS);
       } else {
@@ -106,34 +84,21 @@ class PrintingPlugin extends PrintingPlatform {
         _pdfJsUrlBase = '$_pdfJsCdnPath@$pdfJsVersion/build/';
       }
 
-      final script = web.HTMLScriptElement()
-        ..type = 'text/javascript'
-        ..async = true
-        ..src = '${_pdfJsUrlBase}pdf.min.js';
-      assert(web.document.head != null);
-      web.document.head!.append(script);
-      await script.onLoad.first;
-
-      if (amd != null) {
-        // Re-enable requireJs
-        define!.setProperty('amd'.toJS, amd);
-      }
-
-      web.window
-          .getProperty<js.JSObject>('pdfjsLib'.toJS)
-          .getProperty<js.JSObject>('GlobalWorkerOptions'.toJS)
-          .setProperty(
-            'workerSrc'.toJS,
-            '${_pdfJsUrlBase}pdf.worker.min.js'.toJS,
-          );
-
-      // Restore module and exports
-      if (module != null) {
-        web.window.module = module;
-      }
-      if (exports != null) {
-        web.window.exports = exports;
-      }
+      // pdf.js 4+ ships ES modules only (.mjs), so load it with a dynamic
+      // import() instead of a classic <script> tag.
+      final importUrl = '${_pdfJsUrlBase}pdf.min.mjs';
+      final workerUrl = '${_pdfJsUrlBase}pdf.worker.min.mjs';
+      await web.window
+          .callMethod<js.JSPromise>(
+            'eval'.toJS,
+            '''(async function() {
+              var m = await import("$importUrl");
+              window.pdfjsLib = m;
+              m.GlobalWorkerOptions.workerSrc = "$workerUrl";
+            })()'''
+                .toJS,
+          )
+          .toDart;
     }
 
     _loading.release();
@@ -429,9 +394,4 @@ class _WebPdfRaster extends PdfRaster {
   Future<Uint8List> toPng() async {
     return png;
   }
-}
-
-extension _WindowModule on web.Window {
-  external set module(js.JSObject? value);
-  external set exports(js.JSObject? value);
 }


### PR DESCRIPTION
on web, printing pins pdf.js 3.2.146, which is vulnerable to [CVE-2024-4367](https://github.com/advisories/GHSA-wgrm-67xf-hhpq) (arbitrary js execution from a crafted pdf, fixed in pdf.js 4.2.67). this bumps to 4.2.67 and switches the web loader so a patched version can actually load.

fixes #1939.

why the loader has to change: pdf.js 4.0 dropped the umd build (`pdf.min.js`) and ships esm only (`pdf.min.mjs`) from 4.x on, so the existing `<script src=pdf.min.js>` injection can't load any patched version (it 404s). a version bump on its own isn't enough.

what's in `printing_web.dart`:
- bump `_pdfJsVersion` 3.2.146 -> 4.2.67
- load pdf.js with a dynamic `import()` of `pdf.min.mjs`, setting `window.pdfjsLib` and `GlobalWorkerOptions.workerSrc` to the `.mjs` worker. the import is wrapped in `eval()` so the dart->js compiler doesn't try to resolve it at build time. the package already uses `eval` in `_hasPdfJsLib`, so no new csp requirement.
- drop the amd/webpack global save/restore and the `_WindowModule` extension, which only existed to keep the umd build from tripping over requirejs/webpack.

the `dartPdfJsBaseUrl` / `dartPdfJsVersion` overrides still work.

heads up for self-hosters: anyone overriding `dartPdfJsBaseUrl` to a local copy now needs the `.mjs` build (`pdf.min.mjs` + `pdf.worker.min.mjs`) instead of `pdf.min.js`. probably worth a changelog line.

this is the minimal-version variant. #1941 is the same loader change pinned to the current 5.x if you'd rather take that. we've been running the 5.x one in prod for a few weeks; the loader is identical, only the pinned version differs.
