### PR TITLE
Fix iOS crash in pickPrinter when the selected printer has a nil URL

### DIFF
--- a/printing/ios/Classes/PrintJob.swift
+++ b/printing/ios/Classes/PrintJob.swift
@@ -340,8 +340,15 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
             }
 
             let printer = printerPickerController.selectedPrinter!
+            // UIPrinter.url is non-optional in Swift but the underlying ObjC NSURL can be
+            // nil for partially resolved printers (e.g. discovered over a personal hotspot);
+            // force-bridging a nil NSURL to URL traps at runtime. Read it via KVC instead.
+            guard let url = printer.value(forKey: "URL") as? URL else {
+                result(nil)
+                return
+            }
             let data: NSDictionary = [
-                "url": printer.url.absoluteString as Any,
+                "url": url.absoluteString as Any,
                 "name": printer.displayName as Any,
                 "model": printer.makeAndModel as Any,
                 "location": printer.displayLocation as Any,


### PR DESCRIPTION
## Problem

On iOS, selecting a printer in the native picker (`Printing.pickPrinter` → `UIPrinterPickerController`) crashes the whole app when the picker dismisses, if the selected `UIPrinter` has a nil URL.

`UIPrinter.url` is non-optional in Swift, but the underlying ObjC `NSURL` can be **nil** for a partially resolved printer — e.g. one discovered over a personal hotspot where mDNS resolution is incomplete. Force-bridging that nil `NSURL` to a Swift `URL` traps the runtime:

```
0  Foundation   URL._unconditionallyBridgeFromObjectiveC(_:)   ← EXC_BREAKPOINT / SIGTRAP
1  printing     pickPrinter completion handler thunk
2  PrintKitUI   -[UIPrinterPickerController _printerPickerDidDismiss]
```

Reproduced 2/2 on a physical iPad (iPadOS 26.5), printing 5.14.3.

## Fix

Read the URL via KVC (`printer.value(forKey: "URL") as? URL`), which yields an optional instead of trapping. When nil, return `result(nil)` — the same outcome as cancelling the picker — instead of crashing.

iOS only; 8 lines changed in `PrintJob.swift`. No behavior change for printers that resolve normally.