### PR TITLE
Fix memory initialization in print_job.cpp

### DIFF
--- a/printing/windows/print_job.cpp
+++ b/printing/windows/print_job.cpp
@@ -94,7 +94,7 @@ bool PrintJob::printPdf(const std::string& name,
   if (usePrinterSettings) {
     dm = nullptr;  // to use default driver config
   } else {
-    ZeroMemory(dm, sizeof(DEVMODE));
+    ZeroMemory(dm, dmSize + dmExtra);
     dm->dmSize = (WORD)dmSize;
     dm->dmDriverExtra = (WORD)dmExtra;
     dm->dmFields =


### PR DESCRIPTION
Updated ZeroMemory to use dmSize and dmExtra for memory initialization.