### PR TITLE
fix(printing/ios): UIScene-safe window lookup (fixes convertHtml crash on iOS 26)

### DIFF
--- a/printing/ios/printing/Sources/printing/PrintJob.swift
+++ b/printing/ios/printing/Sources/printing/PrintJob.swift
@@ -254,6 +254,21 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
         )
     }
 
+    // UIScene-safe key window lookup. `UIApplication.shared.keyWindow` and
+    // `UIApplication.shared.delegate.window` are nil under UISceneDelegate
+    // (deprecated in iOS 26, mandatory when building with the iOS 27 SDK), so
+    // resolve the key window from the connected window scenes instead.
+    static func sceneKeyWindow() -> UIWindow? {
+        if #available(iOS 13.0, *) {
+            let windows = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+            return windows.first(where: { $0.isKeyWindow }) ?? windows.first
+        }
+        // iOS < 13 has no UIScene; fall back to the app delegate's window.
+        return UIApplication.shared.delegate?.window ?? nil
+    }
+
     static func sharePdf(data: Data, withSourceRect rect: CGRect, andName name: String, subject: String?, body: String?) {
         let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         let fileURL = tmpDirURL.appendingPathComponent(name)
@@ -268,16 +283,22 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
         let activityViewController = UIActivityViewController(activityItems: [fileURL, body as Any], applicationActivities: nil)
         activityViewController.setValue(subject, forKey: "subject")
         if UIDevice.current.userInterfaceIdiom == .pad {
-            let controller: UIViewController? = UIApplication.shared.keyWindow?.rootViewController
+            let controller: UIViewController? = PrintJob.sceneKeyWindow()?.rootViewController
             activityViewController.popoverPresentationController?.sourceView = controller?.view
             activityViewController.popoverPresentationController?.sourceRect = rect
         }
-        UIApplication.shared.keyWindow?.rootViewController?.present(activityViewController, animated: true)
+        PrintJob.sceneKeyWindow()?.rootViewController?.present(activityViewController, animated: true)
     }
 
     func convertHtml(_ data: String, withPageSize rect: CGRect, andMargin margin: CGRect, andBaseUrl baseUrl: URL?) {
-        let viewController = UIApplication.shared.delegate?.window?!.rootViewController
-        let wkWebView = WKWebView(frame: viewController!.view.bounds)
+        // UIScene fix: delegate.window is nil under UISceneDelegate; force-
+        // unwrapping it crashed convertHtml. Use the scene key window instead.
+        let viewController = PrintJob.sceneKeyWindow()?.rootViewController
+        guard let rootView = viewController?.view else {
+            printing.onHtmlError(printJob: self, error: "No key window available to render HTML to PDF")
+            return
+        }
+        let wkWebView = WKWebView(frame: rootView.bounds)
         wkWebView.isHidden = true
         wkWebView.tag = 100
         viewController?.view.addSubview(wkWebView)
@@ -362,7 +383,7 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
         }
 
         if UIDevice.current.userInterfaceIdiom == .pad {
-            let viewController: UIViewController? = UIApplication.shared.keyWindow?.rootViewController
+            let viewController: UIViewController? = PrintJob.sceneKeyWindow()?.rootViewController
             if viewController != nil {
                 controller.present(from: rect, in: viewController!.view, animated: true, completionHandler: pickPrinterCompletionHandler)
                 return


### PR DESCRIPTION
## Problem

On iOS, `PrintJob.convertHtml` resolves the root view controller via:

```swift
let viewController = UIApplication.shared.delegate?.window?!.rootViewController
```

Under `UISceneDelegate` — which Apple deprecates in iOS 26 and makes **mandatory when building with the iOS 27 SDK** (see [TN3187](https://developer.apple.com/documentation/technotes/tn3187-migrating-to-the-uikit-scene-based-life-cycle)) — the window is owned by the scene, so `UIApplication.shared.delegate.window` (and `UIApplication.shared.keyWindow`) is `nil`. The force-unwrap (`?!`) then crashes with:

```
Fatal error: Unexpectedly found nil while unwrapping an Optional value
```

whenever the app converts HTML to a PDF (e.g. `Printing.convertHtml`). This is not catchable from Dart. `sharePdf` and `pickPrinter` use the same deprecated `keyWindow` lookup and silently fail to present under scenes.

## Fix

Add a `sceneKeyWindow()` helper that resolves the key window from `UIApplication.shared.connectedScenes` (guarded with `if #available(iOS 13.0, *)`, with a pre-scene fallback to `delegate.window`), and use it in `convertHtml`, `sharePdf` and `pickPrinter`. `convertHtml` now guards the view controller and reports `onHtmlError` instead of crashing when no window is available.

Tested on an iPad Pro (iOS 26 simulator) with a Flutter app using the default `UISceneDelegate` lifecycle: `Printing.convertHtml` renders the PDF instead of crashing.
