### PR TITLE
printing/ios: fix use-after-free race on PrintJob.pdfDocument

### DIFF
--- a/printing/CHANGELOG.md
+++ b/printing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.15.2
+
+- Fix iOS use-after-free crash in `CGPDFDocumentGetNumberOfPages`: UIKit reads the PDF document from a background page-count thread while dynamic layout replaces it on the main thread; document access is now lock-guarded
+
 ## 5.15.1
 
 - Fix layoutPdf hanging forever in iOS App Store builds: return the document via the method-channel reply instead of a dlsym FFI callback, whose symbols are stripped from statically linked (Swift Package Manager) apps by distribution builds

--- a/printing/ios/printing/Sources/printing/PrintJob.swift
+++ b/printing/ios/printing/Sources/printing/PrintJob.swift
@@ -27,7 +27,28 @@ var pickedPrinter: UIPrinter?
 public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate {
     private var printing: PrintingPlugin
     public var index: Int
-    private var pdfDocument: CGPDFDocument?
+    private let pdfDocumentLock = NSLock()
+    private var _pdfDocument: CGPDFDocument?
+    // UIKit queries numberOfPages from a background page-count thread
+    // (UIPrintPreviewViewController.updatePageCount) while setDocument and
+    // cancelJob replace the document on the main thread. An unsynchronized
+    // swap lets ARC free the old CGPDFDocument mid-read, crashing in
+    // CGPDFDocumentGetNumberOfPages. All access must go through this lock;
+    // the getter retains the document under the lock so callers always hold
+    // a strong reference to a live object.
+    private var pdfDocument: CGPDFDocument? {
+        get {
+            pdfDocumentLock.lock()
+            defer { pdfDocumentLock.unlock() }
+            return _pdfDocument
+        }
+        set {
+            pdfDocumentLock.lock()
+            defer { pdfDocumentLock.unlock() }
+            _pdfDocument = newValue
+        }
+    }
+
     private var urlObservation: NSKeyValueObservation?
     private var jobName: String?
     private var printerName: String?
@@ -40,13 +61,15 @@ public class PrintJob: UIPrintPageRenderer, UIPrintInteractionControllerDelegate
     public init(printing: PrintingPlugin, index: Int) {
         self.printing = printing
         self.index = index
-        pdfDocument = nil
         super.init()
     }
 
     override public func drawPage(at pageIndex: Int, in _: CGRect) {
         let ctx = UIGraphicsGetCurrentContext()
-        let page = pdfDocument?.page(at: pageIndex + 1)
+        // Hold a strong local reference so a concurrent setDocument can't
+        // release the document (and the page it owns) while we draw.
+        let document = pdfDocument
+        let page = document?.page(at: pageIndex + 1)
         ctx?.scaleBy(x: 1.0, y: -1.0)
         ctx?.translateBy(x: 0.0, y: -paperRect.size.height)
         if page != nil {

--- a/printing/pubspec.yaml
+++ b/printing/pubspec.yaml
@@ -15,7 +15,7 @@ topics:
   - print
   - printing
   - report
-version: 5.15.1
+version: 5.15.2
 
 environment:
   sdk: ">=3.12.0 <4.0.0"


### PR DESCRIPTION
## Problem

We're seeing production crashes (via Crashlytics) with this signature:

```
Crashed: Thread
0  CoreGraphics   pdf_reader_get_number_of_pages + 32
1  App            PrintJob.numberOfPages.getter (PrintJob.swift)
2  PrintKitUI     -[UIPrintPageRenderer _numberOfPages]
3  PrintKitUI     -[UIPrintInteractionController _updatePageCount]
4  PrintKitUI     __47-[UIPrintPreviewViewController updatePageCount]_block_invoke
5  Foundation     __NSThread__start__
```

UIKit queries `UIPrintPageRenderer.numberOfPages` from a background page-count thread (`UIPrintPreviewViewController.updatePageCount`). With dynamic layout (`Printing.layoutPdf`), every `numberOfPages` call triggers `onLayout` → Flutter re-renders → `setDocument` replaces `pdfDocument` on the main thread, releasing the previous `CGPDFDocument`. `cancelJob` can also nil it from the main thread.

Since `pdfDocument` was a plain stored property with no synchronization, a reader on the background thread could load the reference just as the main thread swapped in a new document — ARC frees the old `CGPDFDocument` mid-read and `CGPDFDocumentGetNumberOfPages` runs on freed memory.

## Fix

- Guard `pdfDocument` behind an `NSLock`-protected computed property. The getter retains the document under the lock, so callers always hold a strong reference to a live object; writers (`setDocument`, `cancelJob`) swap under the same lock.
- `drawPage` takes a strong local reference before deriving a `CGPDFPage`, so a concurrent swap can't free the document (and the page it owns) while drawing.

No behavior change otherwise; iOS only.