### PR TITLE
fix(pdf): dpi on Image no longer inflates PDF size (dart_pdf#1841)

### DIFF
--- a/pdf/CHANGELOG.md
+++ b/pdf/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.13.1
+
+- Fix setting a dpi on an Image widget massively inflating the PDF size (dart_pdf#1841): never resample above the source resolution, and keep DCT (JPEG) encoding instead of raw Flate pixels when a JPEG image is downsampled
+
 ## 3.13.0
 
 - Fix lint issues

--- a/pdf/lib/src/widgets/image_provider.dart
+++ b/pdf/lib/src/widgets/image_provider.dart
@@ -49,28 +49,32 @@ abstract class ImageProvider {
   PdfImage resolve(Context context, PdfPoint size, {double? dpi}) {
     final effectiveDpi = dpi ?? this.dpi;
 
-    if (effectiveDpi == null || _cache[0] != null) {
-      _cache[0] ??= buildImage(context);
+    if (effectiveDpi != null && _cache[0] == null) {
+      final width = (size.x / PdfPageFormat.inch * effectiveDpi).toInt();
+      final height = (size.y / PdfPageFormat.inch * effectiveDpi).toInt();
 
-      if (_cache[0]!.pdfDocument != context.document) {
-        _cache[0] = buildImage(context);
+      // Never resample above the source resolution: upscaling adds no detail
+      // but discards the original (possibly better compressed) image data.
+      if (this.width == null || width < this.width!) {
+        if (!_cache.containsKey(width)) {
+          _cache[width] ??= buildImage(context, width: width, height: height);
+        }
+
+        if (_cache[width]!.pdfDocument != context.document) {
+          _cache[width] = buildImage(context, width: width, height: height);
+        }
+
+        return _cache[width]!;
       }
-
-      return _cache[0]!;
     }
 
-    final width = (size.x / PdfPageFormat.inch * effectiveDpi).toInt();
-    final height = (size.y / PdfPageFormat.inch * effectiveDpi).toInt();
+    _cache[0] ??= buildImage(context);
 
-    if (!_cache.containsKey(width)) {
-      _cache[width] ??= buildImage(context, width: width, height: height);
+    if (_cache[0]!.pdfDocument != context.document) {
+      _cache[0] = buildImage(context);
     }
 
-    if (_cache[width]!.pdfDocument != context.document) {
-      _cache[width] = buildImage(context, width: width, height: height);
-    }
-
-    return _cache[width]!;
+    return _cache[0]!;
   }
 }
 
@@ -149,6 +153,16 @@ class MemoryImage extends ImageProvider {
     }
 
     final resized = im.copyResize(image, width: width);
+
+    if (im.JpegDecoder().isValidFile(bytes)) {
+      // Keep DCT (JPEG) encoding for resampled JPEG images: embedding the
+      // raw pixels with Flate compression would inflate the file size.
+      return PdfImage.jpeg(
+        context.document,
+        image: im.encodeJpg(resized, quality: 90),
+      );
+    }
+
     return PdfImage.fromImage(context.document, image: resized);
   }
 }

--- a/pdf/pubspec.yaml
+++ b/pdf/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - print
   - printing
   - report
-version: 3.13.0
+version: 3.13.1
 
 environment:
   sdk: ">=3.12.0 <4.0.0"

--- a/pdf/test/image_test.dart
+++ b/pdf/test/image_test.dart
@@ -16,8 +16,10 @@
 
 import 'dart:typed_data';
 
+import 'package:image/image.dart' as im;
 import 'package:pdf/pdf.dart';
 import 'package:pdf/src/priv.dart';
+import 'package:pdf/widgets.dart' show Context, MemoryImage;
 import 'package:test/test.dart';
 
 const kRedValue = 110;
@@ -88,5 +90,43 @@ void main() {
       expect(buf[pixelIndex * 3 + 1], kGreenValue);
       expect(buf[pixelIndex * 3 + 2], kBlueValue);
     }
+  });
+
+  test('MemoryImage with dpi does not upscale a JPEG image', () async {
+    final jpg = im.encodeJpg(im.Image(width: 100, height: 50));
+
+    final pdf = PdfDocument();
+    final provider = MemoryImage(jpg);
+
+    // 1 x 0.5 inch at 300 dpi requests 300x150, larger than the 100x50
+    // source: the original image must be embedded unchanged.
+    final image = provider.resolve(
+      Context(document: pdf),
+      const PdfPoint(1 * PdfPageFormat.inch, 0.5 * PdfPageFormat.inch),
+      dpi: 300,
+    );
+
+    expect(image.params['/Width'], const PdfNum(100));
+    expect(image.params['/Height'], const PdfNum(50));
+    expect(image.params['/Filter'], const PdfName('/DCTDecode'));
+  });
+
+  test('MemoryImage with dpi keeps JPEG compression when downsampling', () async {
+    final jpg = im.encodeJpg(im.Image(width: 400, height: 200));
+
+    final pdf = PdfDocument();
+    final provider = MemoryImage(jpg);
+
+    // 1 x 0.5 inch at 300 dpi requests 300x150, smaller than the 400x200
+    // source: the image is resampled but must stay DCT (JPEG) encoded.
+    final image = provider.resolve(
+      Context(document: pdf),
+      const PdfPoint(1 * PdfPageFormat.inch, 0.5 * PdfPageFormat.inch),
+      dpi: 300,
+    );
+
+    expect(image.params['/Width'], const PdfNum(300));
+    expect(image.params['/Height'], const PdfNum(150));
+    expect(image.params['/Filter'], const PdfName('/DCTDecode'));
   });
 }


### PR DESCRIPTION
Hi 👋 thanks for dart_pdf!

This fixes #1841 — setting a `dpi` on an `Image` widget could sixfold the PDF size, because 
the image was resampled even above its source resolution and the result was embedded as raw 
Flate pixels instead of DCT.

- `ImageProvider.resolve`: skip resampling when the dpi target is at or above the source
resolution and embed the original image unchanged
- `MemoryImage.buildImage`: re-encode genuinely downsampled JPEG images as JPEG (DCT)
instead of raw pixels
- 2 regression tests

This is the minimal version. A deeper review of the change in our fork surfaced a few
regressions [findings](https://github.com/RocketCodeGmbH/dart_pdf/pull/1) the hardened version including those fixes is up as #1949. If it helps,
I'd also be glad to prepare a follow-up PR for the remaining (mostly pre-existing) findings
from that review.