### PR TITLE
fix(pdf): dpi on Image no longer inflates PDF size, hardened (#1841)

### DIFF
--- a/pdf/CHANGELOG.md
+++ b/pdf/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 3.13.1
 
-- Fix setting a dpi on an Image widget massively inflating the PDF size (dart_pdf#1841): never resample above the source resolution, and keep DCT (JPEG) encoding instead of raw Flate pixels when a JPEG image is downsampled
+- Fix setting a dpi on an Image widget massively inflating the PDF size (dart_pdf#1841): never resample above the source resolution, and keep DCT (JPEG) encoding instead of raw Flate pixels when a JPEG image is downsampled. Note that downsampled JPEG images are re-encoded at quality 90 (lossy); omit dpi to embed the original bytes unchanged
+- Check the no-upscale rule against the decoded pixels, so rotated images can no longer be accidentally upscaled, and keep the original image when the source resolution is unknown
+- Keep dpi downsampling working after the same image was resolved at or above its source resolution
+- Strip the source EXIF metadata (GPS position, device serial numbers, ...) from downsampled JPEG images instead of copying it into the document
 
 ## 3.13.0
 

--- a/pdf/CHANGELOG.md
+++ b/pdf/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.13.1
+
+- Fix setting a dpi on an Image widget massively inflating the PDF size (dart_pdf#1841): never resample above the source resolution, and keep DCT (JPEG) encoding instead of raw Flate pixels when a JPEG image is downsampled
+
 ## 3.13.0
 
 - Fix lint issues

--- a/pdf/lib/src/widgets/image_provider.dart
+++ b/pdf/lib/src/widgets/image_provider.dart
@@ -49,28 +49,32 @@ abstract class ImageProvider {
   PdfImage resolve(Context context, PdfPoint size, {double? dpi}) {
     final effectiveDpi = dpi ?? this.dpi;
 
-    if (effectiveDpi == null || _cache[0] != null) {
-      _cache[0] ??= buildImage(context);
+    if (effectiveDpi != null && _cache[0] == null) {
+      final width = (size.x / PdfPageFormat.inch * effectiveDpi).toInt();
+      final height = (size.y / PdfPageFormat.inch * effectiveDpi).toInt();
 
-      if (_cache[0]!.pdfDocument != context.document) {
-        _cache[0] = buildImage(context);
+      // Never resample above the source resolution: upscaling adds no detail
+      // but discards the original (possibly better compressed) image data.
+      if (this.width == null || width < this.width!) {
+        if (!_cache.containsKey(width)) {
+          _cache[width] ??= buildImage(context, width: width, height: height);
+        }
+
+        if (_cache[width]!.pdfDocument != context.document) {
+          _cache[width] = buildImage(context, width: width, height: height);
+        }
+
+        return _cache[width]!;
       }
-
-      return _cache[0]!;
     }
 
-    final width = (size.x / PdfPageFormat.inch * effectiveDpi).toInt();
-    final height = (size.y / PdfPageFormat.inch * effectiveDpi).toInt();
+    _cache[0] ??= buildImage(context);
 
-    if (!_cache.containsKey(width)) {
-      _cache[width] ??= buildImage(context, width: width, height: height);
+    if (_cache[0]!.pdfDocument != context.document) {
+      _cache[0] = buildImage(context);
     }
 
-    if (_cache[width]!.pdfDocument != context.document) {
-      _cache[width] = buildImage(context, width: width, height: height);
-    }
-
-    return _cache[width]!;
+    return _cache[0]!;
   }
 }
 
@@ -149,6 +153,16 @@ class MemoryImage extends ImageProvider {
     }
 
     final resized = im.copyResize(image, width: width);
+
+    if (im.JpegDecoder().isValidFile(bytes)) {
+      // Keep DCT (JPEG) encoding for resampled JPEG images: embedding the
+      // raw pixels with Flate compression would inflate the file size.
+      return PdfImage.jpeg(
+        context.document,
+        image: im.encodeJpg(resized, quality: 90),
+      );
+    }
+
     return PdfImage.fromImage(context.document, image: resized);
   }
 }

--- a/pdf/lib/src/widgets/image_provider.dart
+++ b/pdf/lib/src/widgets/image_provider.dart
@@ -49,13 +49,25 @@ abstract class ImageProvider {
   PdfImage resolve(Context context, PdfPoint size, {double? dpi}) {
     final effectiveDpi = dpi ?? this.dpi;
 
-    if (effectiveDpi != null && _cache[0] == null) {
+    if (effectiveDpi != null) {
       final width = (size.x / PdfPageFormat.inch * effectiveDpi).toInt();
       final height = (size.y / PdfPageFormat.inch * effectiveDpi).toInt();
 
       // Never resample above the source resolution: upscaling adds no detail
       // but discards the original (possibly better compressed) image data.
-      if (this.width == null || width < this.width!) {
+      // For rotated orientations the axis buildImage resizes depends on
+      // whether decoding bakes the rotation into the pixels, so only an
+      // upper bound is checked here; buildImage itself skips the resample
+      // when the target is at or above the decoded pixel width. An unknown
+      // source width keeps the original: it cannot be proven a downsample.
+      final sourceWidth = _width;
+      final resampleBound = sourceWidth == null
+          ? null
+          : orientation.index >= 4
+          ? (sourceWidth > _height ? sourceWidth : _height)
+          : sourceWidth;
+
+      if (resampleBound != null && width > 0 && width < resampleBound) {
         if (!_cache.containsKey(width)) {
           _cache[width] ??= buildImage(context, width: width, height: height);
         }
@@ -152,9 +164,21 @@ class MemoryImage extends ImageProvider {
       throw PdfException('Unable decode the image');
     }
 
+    // The decoded (orientation-baked) pixels are the ground truth for the
+    // no-upscale rule: for rotated images the metadata bound checked by
+    // resolve() cannot know which axis copyResize will scale.
+    if (width >= image.width) {
+      return PdfImage.file(context.document, bytes: bytes);
+    }
+
     final resized = im.copyResize(image, width: width);
 
     if (im.JpegDecoder().isValidFile(bytes)) {
+      // Do not carry the source metadata over: EXIF can hold sensitive data
+      // (GPS position, device serial numbers) and its orientation is already
+      // baked into the decoded pixels.
+      resized.exif = im.ExifData();
+
       // Keep DCT (JPEG) encoding for resampled JPEG images: embedding the
       // raw pixels with Flate compression would inflate the file size.
       return PdfImage.jpeg(
@@ -181,7 +205,9 @@ class ImageImage extends ImageProvider {
 
   @override
   PdfImage buildImage(Context context, {int? width, int? height}) {
-    if (width == null) {
+    // Resampling at or above the pixel width could only upscale: keep the
+    // original pixels (see ImageProvider.resolve).
+    if (width == null || width >= _image.width) {
       return PdfImage.fromImage(context.document, image: _image);
     }
 

--- a/pdf/pubspec.yaml
+++ b/pdf/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - print
   - printing
   - report
-version: 3.13.0
+version: 3.13.1
 
 environment:
   sdk: ">=3.12.0 <4.0.0"

--- a/pdf/test/image_test.dart
+++ b/pdf/test/image_test.dart
@@ -16,8 +16,10 @@
 
 import 'dart:typed_data';
 
+import 'package:image/image.dart' as im;
 import 'package:pdf/pdf.dart';
 import 'package:pdf/src/priv.dart';
+import 'package:pdf/widgets.dart' show Context, MemoryImage;
 import 'package:test/test.dart';
 
 const kRedValue = 110;
@@ -88,5 +90,43 @@ void main() {
       expect(buf[pixelIndex * 3 + 1], kGreenValue);
       expect(buf[pixelIndex * 3 + 2], kBlueValue);
     }
+  });
+
+  test('MemoryImage with dpi does not upscale a JPEG image', () async {
+    final jpg = im.encodeJpg(im.Image(width: 100, height: 50));
+
+    final pdf = PdfDocument();
+    final provider = MemoryImage(jpg);
+
+    // 1 x 0.5 inch at 300 dpi requests 300x150, larger than the 100x50
+    // source: the original image must be embedded unchanged.
+    final image = provider.resolve(
+      Context(document: pdf),
+      const PdfPoint(1 * PdfPageFormat.inch, 0.5 * PdfPageFormat.inch),
+      dpi: 300,
+    );
+
+    expect(image.params['/Width'], const PdfNum(100));
+    expect(image.params['/Height'], const PdfNum(50));
+    expect(image.params['/Filter'], const PdfName('/DCTDecode'));
+  });
+
+  test('MemoryImage with dpi keeps JPEG compression when downsampling', () async {
+    final jpg = im.encodeJpg(im.Image(width: 400, height: 200));
+
+    final pdf = PdfDocument();
+    final provider = MemoryImage(jpg);
+
+    // 1 x 0.5 inch at 300 dpi requests 300x150, smaller than the 400x200
+    // source: the image is resampled but must stay DCT (JPEG) encoded.
+    final image = provider.resolve(
+      Context(document: pdf),
+      const PdfPoint(1 * PdfPageFormat.inch, 0.5 * PdfPageFormat.inch),
+      dpi: 300,
+    );
+
+    expect(image.params['/Width'], const PdfNum(300));
+    expect(image.params['/Height'], const PdfNum(150));
+    expect(image.params['/Filter'], const PdfName('/DCTDecode'));
   });
 }

--- a/pdf/test/image_test.dart
+++ b/pdf/test/image_test.dart
@@ -201,6 +201,25 @@ void main() {
     expect(image.params['/Height'], const PdfNum(200));
   });
 
+  test('degenerate zero target width keeps the original image', () async {
+    final jpg = im.encodeJpg(im.Image(width: 400, height: 200));
+
+    final pdf = PdfDocument();
+    final provider = MemoryImage(jpg);
+
+    // A sub-pixel box computes a target width of 0, which must not be
+    // resampled — and must not poison the cache slot of the original.
+    final tiny = provider.resolve(
+      Context(document: pdf),
+      const PdfPoint(0.3, 0.3),
+      dpi: 72,
+    );
+    expect(tiny.params['/Width'], const PdfNum(400));
+
+    final original = provider.resolve(Context(document: pdf), PdfPoint.zero);
+    expect(original.params['/Width'], const PdfNum(400));
+  });
+
   test('unknown source width requests the original image', () async {
     final pdf = PdfDocument();
     final provider = _UnknownWidthImage();

--- a/pdf/test/image_test.dart
+++ b/pdf/test/image_test.dart
@@ -19,7 +19,8 @@ import 'dart:typed_data';
 import 'package:image/image.dart' as im;
 import 'package:pdf/pdf.dart';
 import 'package:pdf/src/priv.dart';
-import 'package:pdf/widgets.dart' show Context, MemoryImage;
+import 'package:pdf/widgets.dart'
+    show Context, ImageImage, ImageProvider, MemoryImage;
 import 'package:test/test.dart';
 
 const kRedValue = 110;
@@ -111,14 +112,65 @@ void main() {
     expect(image.params['/Filter'], const PdfName('/DCTDecode'));
   });
 
-  test('MemoryImage with dpi keeps JPEG compression when downsampling', () async {
+  test(
+    'MemoryImage with dpi keeps JPEG compression when downsampling',
+    () async {
+      final jpg = im.encodeJpg(im.Image(width: 400, height: 200));
+
+      final pdf = PdfDocument();
+      final provider = MemoryImage(jpg);
+
+      // 1 x 0.5 inch at 300 dpi requests 300x150, smaller than the 400x200
+      // source: the image is resampled but must stay DCT (JPEG) encoded.
+      final image = provider.resolve(
+        Context(document: pdf),
+        const PdfPoint(1 * PdfPageFormat.inch, 0.5 * PdfPageFormat.inch),
+        dpi: 300,
+      );
+
+      expect(image.params['/Width'], const PdfNum(300));
+      expect(image.params['/Height'], const PdfNum(150));
+      expect(image.params['/Filter'], const PdfName('/DCTDecode'));
+    },
+  );
+
+  test('MemoryImage keeps downsampling after an at-source resolve', () async {
     final jpg = im.encodeJpg(im.Image(width: 400, height: 200));
 
     final pdf = PdfDocument();
     final provider = MemoryImage(jpg);
 
+    // 2 x 1 inch at 300 dpi requests 600x300, above the 400x200 source:
+    // the original image is embedded.
+    final large = provider.resolve(
+      Context(document: pdf),
+      const PdfPoint(2 * PdfPageFormat.inch, 1 * PdfPageFormat.inch),
+      dpi: 300,
+    );
+    expect(large.params['/Width'], const PdfNum(400));
+
+    // A later, smaller placement of the same provider must still be
+    // downsampled: 1 x 0.5 inch at 150 dpi requests 150x75.
+    final small = provider.resolve(
+      Context(document: pdf),
+      const PdfPoint(1 * PdfPageFormat.inch, 0.5 * PdfPageFormat.inch),
+      dpi: 150,
+    );
+    expect(small.params['/Width'], const PdfNum(150));
+  });
+
+  test('MemoryImage strips EXIF metadata when downsampling a JPEG', () async {
+    final src = im.Image(width: 400, height: 200);
+    src.exif.imageIfd['Make'] = 'TestCam';
+    final jpg = im.encodeJpg(src);
+    expect(im.decodeJpg(jpg)!.exif.isEmpty, isFalse);
+
+    final pdf = PdfDocument();
+    final provider = MemoryImage(jpg);
+
     // 1 x 0.5 inch at 300 dpi requests 300x150, smaller than the 400x200
-    // source: the image is resampled but must stay DCT (JPEG) encoded.
+    // source: the image is re-encoded and must not carry the source EXIF
+    // (GPS position, device serial numbers, ...) into the document.
     final image = provider.resolve(
       Context(document: pdf),
       const PdfPoint(1 * PdfPageFormat.inch, 0.5 * PdfPageFormat.inch),
@@ -126,7 +178,56 @@ void main() {
     );
 
     expect(image.params['/Width'], const PdfNum(300));
-    expect(image.params['/Height'], const PdfNum(150));
-    expect(image.params['/Filter'], const PdfName('/DCTDecode'));
+    expect(im.decodeJpg(image.buf.output())!.exif.isEmpty, isTrue);
   });
+
+  test('rotated ImageImage is never upscaled past its pixel width', () async {
+    final raw = im.Image(width: 50, height: 200);
+
+    final pdf = PdfDocument();
+    final provider = ImageImage(raw, orientation: PdfImageOrientation.rightTop);
+
+    // Shown 1 inch wide at 100 dpi the display width targets 100 pixels,
+    // which the orientation-swapped metadata (200) would allow, but the
+    // raw buffer is only 50 pixels wide: resampling could only upscale,
+    // so the original pixels must be embedded.
+    final image = provider.resolve(
+      Context(document: pdf),
+      const PdfPoint(1 * PdfPageFormat.inch, 4 * PdfPageFormat.inch),
+      dpi: 100,
+    );
+
+    expect(image.params['/Width'], const PdfNum(50));
+    expect(image.params['/Height'], const PdfNum(200));
+  });
+
+  test('unknown source width requests the original image', () async {
+    final pdf = PdfDocument();
+    final provider = _UnknownWidthImage();
+
+    // With no source width there is no way to tell whether resampling
+    // would upscale: the original image must be requested.
+    provider.resolve(
+      Context(document: pdf),
+      const PdfPoint(8 * PdfPageFormat.inch, 8 * PdfPageFormat.inch),
+      dpi: 300,
+    );
+
+    expect(provider.lastRequestedWidth, isNull);
+  });
+}
+
+class _UnknownWidthImage extends ImageProvider {
+  _UnknownWidthImage() : super(null, 200, PdfImageOrientation.topLeft, null);
+
+  int? lastRequestedWidth;
+
+  @override
+  PdfImage buildImage(Context context, {int? width, int? height}) {
+    lastRequestedWidth = width;
+    return PdfImage.fromImage(
+      context.document,
+      image: im.Image(width: 10, height: 10),
+    );
+  }
 }


### PR DESCRIPTION
Hi 👋 companion to ##1948 - the same fix for #1841, plus fixes for the regressions a 
deep review of it surfaced ([findings](https://github.com/RocketCodeGmbH/dart_pdf/pull/1) ):

- **EXIF privacy leak**: re-encoded JPEGs carried the source EXIF (GPS position, device
serials) into the PDF — now stripped; orientation is already baked into the pixels
- **Order-dependent dpi**: after one resolve hit the at-or-above-source path, later resolves
of the same provider silently stopped downsampling — the target is now evaluated on every
resolve (plus a guard against a zero-width target poisoning the cache) 
- **Rotated images**: the no-upscale guard compared the orientation-swapped metadata width
while `copyResize` scales the raw pixel axis, so rotated images could be upscaled straight
through it — the rule is now enforced against the decoded pixel width in `buildImage`

5 additional regression tests, each written to fail on the minimal version first. Take
whichever of the two you prefer — and I'd be glad to prepare a follow-up PR for the 
remaining (mostly pre-existing) review findings (interpolation default, repeated JPEG 
re-sniffing, cross-document caching, …) if you'd like.


