### PR TITLE
Fix dartPdfJsBaseUrl JS interop on web

### DIFF
--- a/printing/CHANGELOG.md
+++ b/printing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.15.2
+
+- Fix TypeError when reading `dartPdfJsBaseUrl` for a local Pdf.js path on web [khlebobul]
+
 ## 5.15.1
 
 - Fix layoutPdf hanging forever in iOS App Store builds: return the document via the method-channel reply instead of a dlsym FFI callback, whose symbols are stripped from statically linked (Swift Package Manager) apps by distribution builds

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -73,7 +73,9 @@ class PrintingPlugin extends PrintingPlatform {
       // Check if the source of PDF.js library is overridden via
       // [dartPdfJsBaseUrl] JavaScript variable.
       if (web.window.hasProperty(_dartPdfJsBaseUrl.toJS).toDart) {
-        _pdfJsUrlBase = web.window.getProperty(_dartPdfJsBaseUrl.toJS);
+        _pdfJsUrlBase = web.window
+            .getProperty<js.JSString?>(_dartPdfJsBaseUrl.toJS)!
+            .toDart;
       } else {
         final pdfJsVersion =
             web.window.hasProperty(_dartPdfJsVersion.toJS).toDart

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -73,9 +73,7 @@ class PrintingPlugin extends PrintingPlatform {
       // Check if the source of PDF.js library is overridden via
       // [dartPdfJsBaseUrl] JavaScript variable.
       if (web.window.hasProperty(_dartPdfJsBaseUrl.toJS).toDart) {
-        _pdfJsUrlBase = web.window
-            .getProperty<js.JSString?>(_dartPdfJsBaseUrl.toJS)!
-            .toDart;
+        _pdfJsUrlBase = web.window.getProperty(_dartPdfJsBaseUrl.toJS);
       } else {
         final pdfJsVersion =
             web.window.hasProperty(_dartPdfJsVersion.toJS).toDart
@@ -303,7 +301,11 @@ class PrintingPlugin extends PrintingPlatform {
   ) async* {
     await _initPlugin();
 
-    final settings = Settings()..data = document.toJS;
+    // PDF.js transfers the ArrayBuffer to its worker (detaching it).
+    // Copy on the JS side so postMessage always gets a transferable buffer.
+    final jsData = Uint8List.fromList(document).toJS.callMethod<js.JSUint8Array>('slice'.toJS);
+    final settings = Settings()..data = jsData;
+
 
     if (!_hasPdfJsLib) {
       settings


### PR DESCRIPTION
## Summary
- Fix TypeError when `dartPdfJsBaseUrl` is set in `index.html` for a local Pdf.js path #1840
- Align property read with existing `dartPdfJsVersion` handling (`getProperty<JSString?>` + `.toDart`)

Thanks @redaktorscha for that