### PR TITLE
fix(printing): copy PDF bytes before pdf.js raster on web

### DIFF
--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -301,7 +301,10 @@ class PrintingPlugin extends PrintingPlatform {
   ) async* {
     await _initPlugin();
 
-    final settings = Settings()..data = document.toJS;
+    // pdf.js 4+ transfers TypedArrays to the worker and takes ownership of the
+    // buffer, which neuters the caller's Uint8List. Copy first so the app can
+    // still download/share the same document bytes after preview rasterization.
+    final settings = Settings()..data = Uint8List.fromList(document).toJS;
 
     if (!_hasPdfJsLib) {
       settings


### PR DESCRIPTION
pdf.js 4+ transfers TypedArrays to the worker and neuters the caller's buffer, which left downloads empty after preview. Pass a copy to getDocument so share/download still has valid bytes.

Fixes: #1952 
Fixes: #1953 