### PR TITLE
Fix the simple /TrueType font path and add a setting to select it

### DIFF
--- a/pdf/lib/src/pdf/document.dart
+++ b/pdf/lib/src/pdf/document.dart
@@ -75,12 +75,14 @@ class PdfDocument {
     bool compress = true,
     bool verbose = false,
     PdfVersion version = PdfVersion.pdf_1_5,
+    bool simpleTrueTypeFonts = false,
   }) : prev = null,
        _objser = 1 {
     settings = PdfSettings(
       deflate: compress ? (deflate ?? defaultDeflate) : null,
       verbose: verbose,
       version: version,
+      simpleTrueTypeFonts: simpleTrueTypeFonts,
       encryptCallback: (input, object) =>
           encryption?.encrypt(input, object) ?? input,
     );

--- a/pdf/lib/src/pdf/format/object_base.dart
+++ b/pdf/lib/src/pdf/format/object_base.dart
@@ -43,6 +43,7 @@ class PdfSettings {
     this.encryptCallback,
     this.verbose = false,
     this.version = PdfVersion.pdf_1_5,
+    this.simpleTrueTypeFonts = false,
   });
 
   /// Callback to compress the streams in the pdf file.
@@ -58,6 +59,16 @@ class PdfSettings {
 
   /// PDF version to generate
   final PdfVersion version;
+
+  /// Embed TrueType fonts as simple `/TrueType` objects (full font, single-byte
+  /// codes for characters 32-255) instead of subsetted CID `/Type0` fonts.
+  ///
+  /// Some print RIPs reject the CID form and fail the job. Only characters
+  /// 32-255 are encodable in this mode, so it is off by default.
+  ///
+  /// This lives on the settings rather than a static because [PdfDocument.save]
+  /// writes the document on a separate isolate, where statics start fresh.
+  final bool simpleTrueTypeFonts;
 
   /// Compress the document
   bool get compress => deflate != null;

--- a/pdf/lib/src/pdf/obj/font_descriptor.dart
+++ b/pdf/lib/src/pdf/obj/font_descriptor.dart
@@ -43,7 +43,13 @@ class PdfFontDescriptor extends PdfObject<PdfDict> {
 
     params['/FontName'] = PdfName('/${ttfFont.fontName}');
     params['/FontFile2'] = file.ref();
-    params['/Flags'] = PdfNum(ttfFont.font.unicode ? 4 : 32);
+    // 4 = Symbolic, 32 = Nonsymbolic. A symbolic font is defined to use its
+    // built-in encoding, so consumers may ignore /Encoding entirely; declaring
+    // symbolic alongside /WinAnsiEncoding contradicts itself and lets a strict
+    // RIP resolve glyphs against a (3,0) cmap that simple fonts do not carry.
+    // Key off how the font is actually written, not font.unicode, which only
+    // reports the sfnt version tag.
+    params['/Flags'] = PdfNum(ttfFont.isCidFont ? 4 : 32);
     params['/FontBBox'] = PdfArray.fromNum(<int>[
       (ttfFont.font.xMin / ttfFont.font.unitsPerEm * 1000).toInt(),
       (ttfFont.font.yMin / ttfFont.font.unitsPerEm * 1000).toInt(),

--- a/pdf/lib/src/pdf/obj/ttffont.dart
+++ b/pdf/lib/src/pdf/obj/ttffont.dart
@@ -47,8 +47,22 @@ class PdfTtfFont extends PdfFont {
     widthsObject = PdfObject<PdfArray>(pdfDocument, params: PdfArray());
   }
 
+  /// Whether this font should take the CID `/Type0` path.
+  ///
+  /// Reads [PdfSettings.simpleTrueTypeFonts] rather than a static, because
+  /// [PdfDocument.save] writes on a separate isolate where statics start fresh
+  /// — a static would be seen by putText() but not by prepare().
+  bool get _useType0 => font.unicode && !settings.simpleTrueTypeFonts;
+
+  /// Whether this font is written as a CID `/Type0` font.
+  ///
+  /// Consumers must key off this rather than `font.unicode`, which only reports
+  /// the sfnt version tag and stays true even when the simple `/TrueType` path
+  /// is taken. [PdfFontDescriptor] needs it to pick symbolic vs nonsymbolic.
+  bool get isCidFont => _useType0;
+
   @override
-  String get subtype => font.unicode ? '/Type0' : super.subtype;
+  String get subtype => _useType0 ? '/Type0' : super.subtype;
 
   late PdfUnicodeCmap unicodeCMap;
 
@@ -159,7 +173,7 @@ class PdfTtfFont extends PdfFont {
   void prepare() {
     super.prepare();
 
-    if (font.unicode) {
+    if (_useType0) {
       _buildType0(params);
     } else {
       _buildTrueType(params);
@@ -168,8 +182,10 @@ class PdfTtfFont extends PdfFont {
 
   @override
   void putText(PdfStream stream, String text) {
-    if (!font.unicode) {
-      super.putText(stream, text);
+    if (!_useType0) {
+      // Without the return the simple encoding is emitted and then the hex CID
+      // string is appended on top of it, corrupting the text.
+      return super.putText(stream, text);
     }
 
     final runes = text.runes;

--- a/pdf/lib/src/widgets/document.dart
+++ b/pdf/lib/src/widgets/document.dart
@@ -30,6 +30,7 @@ class Document {
     bool compress = true,
     bool verbose = false,
     PdfVersion version = PdfVersion.pdf_1_5,
+    bool simpleTrueTypeFonts = false,
     this.theme,
     String? title,
     String? author,
@@ -44,6 +45,7 @@ class Document {
          compress: compress,
          verbose: verbose,
          version: version,
+         simpleTrueTypeFonts: simpleTrueTypeFonts,
        ) {
     if (title != null ||
         author != null ||

--- a/pdf/test/simple_truetype_font_test.dart
+++ b/pdf/test/simple_truetype_font_test.dart
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2017, David PHAM-VAN <dev.nfet.net@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'dart:io';
+
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:test/test.dart';
+
+/// Builds a one-page document with [text] in an embedded TrueType font and
+/// returns the raw PDF, so the font dictionaries and content streams can be
+/// matched directly.
+Future<String> buildPdf(String text, {required bool simple}) async {
+  final data = File('open-sans.ttf').readAsBytesSync();
+  final ttf = pw.Font.ttf(data.buffer.asByteData());
+
+  // Uncompressed so the output is greppable. This changes the stream filters
+  // only, not the font structure under test.
+  final doc = pw.Document(compress: false, simpleTrueTypeFonts: simple);
+  doc.addPage(
+    pw.Page(
+      pageFormat: PdfPageFormat.a4,
+      build: (_) => pw.Text(text, style: pw.TextStyle(font: ttf, fontSize: 12)),
+    ),
+  );
+  return String.fromCharCodes(await doc.save());
+}
+
+void main() {
+  test('embeds a CID /Type0 font by default', () async {
+    final pdf = await buildPdf('Hello World', simple: false);
+
+    expect(pdf, contains('/Subtype/Type0'));
+    expect(pdf, contains('/Identity-H'));
+    expect(pdf, contains('/CIDFontType2'));
+  });
+
+  test('simpleTrueTypeFonts embeds a simple /TrueType font', () async {
+    final pdf = await buildPdf('Hello World', simple: true);
+
+    expect(pdf, contains('/Subtype/TrueType'));
+    expect(pdf, contains('/FirstChar 32'));
+    expect(pdf, contains('/LastChar 255'));
+    expect(pdf, isNot(contains('/Type0')), reason: 'no CID wrapper remains');
+    expect(pdf, isNot(contains('/Identity-H')));
+    expect(pdf, isNot(contains('/CIDFontType2')));
+  });
+
+  test('simple fonts write single-byte literals, not hex CIDs', () async {
+    final pdf = await buildPdf('Hello World', simple: true);
+
+    // Text is laid out as one run per word.
+    expect(pdf, contains('[(Hello)]TJ'));
+    expect(pdf, contains('[(World)]TJ'));
+
+    // putText() has to return after delegating to super. Without it the hex
+    // CID string is appended on top of the literal and every run is written
+    // twice.
+    expect(
+      RegExp(r'\[\([^)]*\)\]TJ\s*<[0-9a-fA-F]+>').hasMatch(pdf),
+      isFalse,
+      reason: 'text must not be emitted twice',
+    );
+  });
+
+  test('simple fonts are nonsymbolic, CID fonts stay symbolic', () async {
+    // A symbolic font is defined to use its built-in encoding, so declaring
+    // /Flags 4 alongside /WinAnsiEncoding contradicts itself and a consumer
+    // may ignore /Encoding entirely.
+    final simple = await buildPdf('Hello World', simple: true);
+    expect(simple, contains('/Flags 32'));
+
+    final cid = await buildPdf('Hello World', simple: false);
+    expect(cid, contains('/Flags 4'));
+  });
+}


### PR DESCRIPTION
subtype, prepare() and putText() all keyed off font.unicode, which reports the sfnt version tag rather than how the font is written. Any font whose tag is not unicode already took the simple /TrueType path, and that path was broken two ways:

- putText() lacked a return after delegating to super, so the simple single-byte encoding was emitted and then the hex CID string appended on top of it, corrupting every string.
- The font descriptor declared /Flags 4 (Symbolic) alongside /WinAnsiEncoding. A symbolic font is defined to use its built-in encoding, so a consumer may ignore /Encoding and resolve glyphs against a (3,0) cmap that simple fonts do not carry.

Add isCidFont as the predicate for how the font is actually written and key both call sites on it.

Also add PdfSettings.simpleTrueTypeFonts to opt any font onto the simple path, for consumers that reject CID /Type0 fonts. Only characters 32-255 are encodable that way, so it is off by default. It lives on PdfSettings rather than a static because PdfDocument.save writes on a separate isolate, where statics start fresh - a static was seen by putText() but not by prepare().

The new test covers both paths and asserts both fixes directly.