### PR TITLE
fix(printing): update pdf.js to 6.2.108 for GHSA-hq66-cqwq-w95j

### DIFF
--- a/printing/CHANGELOG.md
+++ b/printing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix GHSA-hq66-cqwq-w95j: update pdf.js to 6.2.108
+
 ## 5.15.1
 
 - Fix layoutPdf hanging forever in iOS App Store builds: return the document via the method-channel reply instead of a dlsym FFI callback, whose symbols are stripped from statically linked (Swift Package Manager) apps by distribution builds

--- a/printing/README.md
+++ b/printing/README.md
@@ -49,7 +49,7 @@ for documentation.
 
    ```html
    <script>
-     var dartPdfJsVersion = "3.2.146";
+     var dartPdfJsVersion = "6.2.108";
    </script>
    ```
     5.1. If you want to manually set the alternative location for loading Pdf.js library for the web, the following script has to be added to your `web/index.html` file, just before `</head>`.

--- a/printing/lib/printing_web.dart
+++ b/printing/lib/printing_web.dart
@@ -51,7 +51,7 @@ class PrintingPlugin extends PrintingPlatform {
 
   static const _pdfJsCdnPath = 'https://unpkg.com/pdfjs-dist';
 
-  static const _pdfJsVersion = '5.7.284';
+  static const _pdfJsVersion = '6.2.108';
 
   final _loading = Mutex();
 


### PR DESCRIPTION
Fixes #1959.

Bumps the hardcoded pdf.js version from `5.7.284` to `6.2.108`. `5.7.284` is inside [GHSA-hq66-cqwq-w95j](https://github.com/advisories/GHSA-hq66-cqwq-w95j) (high, arbitrary JavaScript execution on opening a malicious PDF, range `>= 5.6.83, < 6.2.108`). `6.2.108` is the first patched release, so there is no patched 5.x to move to instead.

Three one-line changes:

- `printing/lib/printing_web.dart`: the const
- `printing/CHANGELOG.md`: entry under `## Unreleased` rather than a version heading, so it does not collide with the `## 5.15.2` in #1951. Renumber as you prefer
- `printing/README.md`: the `dartPdfJsVersion` example still showed `3.2.146`, which is the version #1939 was about. Happy to drop this hunk if you would rather keep the PR to two files

The two `dartPdfJsBaseUrl` examples further down also still show `3.2.146`. I left them alone because I cannot verify the cdnjs and local-assets paths they describe for 6.x.

<details>
<summary>compatibility check</summary>

I checked every symbol `printing/lib/src/pdfjs.dart` binds against `pdfjs-dist@6.2.108`, using the published type definitions and the unminified bundle rather than the release notes.

| Item                                                                       | Result                                                                                |
|----------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
| `getDocument`, `GlobalWorkerOptions`                                        | exported                                                                              |
| `data`, `scale`, `viewport`, `cMapUrl`, `cMapPacked`, `numPages`, `getPage`, `getViewport`, `cleanup` | present                                                                               |
| `render({canvasContext, viewport})` with no `canvas`                        | works. `canvas = canvasContext.canvas` is a default parameter (`build/pdf.mjs:15637`)  |
| `jsDoc.destroy()`                                                          | `PDFDocumentLoadingTask.destroy()`, still present                                     |
| `build/pdf.min.mjs`, `build/pdf.worker.min.mjs` at 6.2.108                  | both 200 on unpkg                                                                     |

Two `[api-major]` changes land in pdf.js 6.0:

- mozilla/pdf.js#21245 removes `PDFDocumentProxy.prototype.destroy`. Does not apply: `printing` calls `destroy()` on what `getDocument()` returns, which is the `PDFDocumentLoadingTask`. Only the alias on the proxy was removed
- mozilla/pdf.js#21152 raises the minimum supported browsers to Chrome 125 (2024-05) and Safari 18 (2024-09). This is the one real consequence for downstream users. Those figures are pdf.js's floor for their `legacy` build, and `printing` loads the modern `pdf.min.mjs`, so the effective floor is at least that

The `[api-minor]` Map conversions in 6.1 and 6.2 (`getAttachments`, `getDestinations`, `getViewerPreferences`, `getOpenAction`) touch nothing `printing` calls.
</details>

<details>
<summary>testing</summary>

No test in `printing/test/` exercises `printing_web.dart`, and there is no browser job in `.github/workflows/dart.yaml`, so CI will not cover this either way. What I verified by hand:

- the version const is the only live reference in the repo. The other `5.7.284` occurrence is the 5.15.0 changelog line, left as history
- both 6.2.108 `.mjs` build artifacts resolve on unpkg, which is what `_pdfJsCdnPath` points at
- the render call shape against the actual 6.2.108 source, as above

I have this running in a Flutter web app via the `window.dartPdfJsVersion` override, which exercises the same loader and the same raster path. Real browser QA on the const itself is still worth doing before you cut a release.
</details>

<details>
<summary>note on render</summary>

`canvasContext` is documented in 6.x as the backwards-compatible path, with `canvas` preferred:

```
canvas: HTMLCanvasElement | null;
canvasContext?: CanvasRenderingContext2D | undefined;  // for backwards compatibility
```

It still works, so nothing is needed in this PR. Migrating `_raster` to pass `canvas` would drop off the legacy path whenever you want to.
</details>
